### PR TITLE
feat: 評価シート機能のUI実装 (Phase 2-1, 2-2)

### DIFF
--- a/src/app/(employee)/dashboard/page.tsx
+++ b/src/app/(employee)/dashboard/page.tsx
@@ -1,6 +1,37 @@
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import { MainLayout } from '@/components/layout/main-layout';
+import { phaseLabels } from '@/lib/workflow';
+import { halfLabels } from '@/types/evaluation';
+import type { Phase, Half } from '@prisma/client';
+
+// モックデータ（データベース接続後に置き換え）
+interface MockSheet {
+  id: string;
+  periodName: string;
+  year: number;
+  half: Half;
+  status: Phase;
+  currentPhase: Phase;
+  goalsCount: number;
+  totalWeight: number;
+}
+
+function getMockSheets(): MockSheet[] {
+  return [
+    {
+      id: 'sheet-1',
+      periodName: '2026年度上期',
+      year: 2026,
+      half: 'first',
+      status: 'goal_setting',
+      currentPhase: 'goal_setting',
+      goalsCount: 4,
+      totalWeight: 100,
+    },
+  ];
+}
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -8,6 +39,9 @@ export default async function DashboardPage() {
   if (!session?.user) {
     redirect('/login');
   }
+
+  const sheets = getMockSheets();
+  const currentSheet = sheets[0];
 
   return (
     <MainLayout>
@@ -21,32 +55,123 @@ export default async function DashboardPage() {
           className="ab-grid ab-gap-4"
           style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}
         >
+          {/* 評価シート */}
           <div
             className="ab-bg-base ab-rounded-md ab-p-4"
             style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
           >
             <h2 className="ab-text-heading-m ab-text-default ab-mb-1">評価シート</h2>
             <p className="ab-text-body-s ab-text-secondary ab-mb-4">現在の評価期間のシート</p>
-            <p className="ab-text-body-m ab-text-secondary">評価シートはまだありません</p>
+            {currentSheet ? (
+              <div className="ab-flex ab-flex-column ab-gap-2">
+                <p className="ab-text-body-m ab-text-default">
+                  {currentSheet.year}年 {halfLabels[currentSheet.half]}
+                </p>
+                <div className="ab-flex ab-items-center ab-gap-2">
+                  <span
+                    className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+                    style={{ backgroundColor: '#1976d2', padding: '2px 8px' }}
+                  >
+                    {phaseLabels[currentSheet.status]}
+                  </span>
+                </div>
+                <Link
+                  href={`/sheet/${currentSheet.id}`}
+                  className="ab-text-body-m"
+                  style={{ color: '#1976d2', textDecoration: 'none' }}
+                >
+                  シートを開く →
+                </Link>
+              </div>
+            ) : (
+              <p className="ab-text-body-m ab-text-secondary">評価シートはまだありません</p>
+            )}
           </div>
 
+          {/* 目標進捗 */}
           <div
             className="ab-bg-base ab-rounded-md ab-p-4"
             style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
           >
             <h2 className="ab-text-heading-m ab-text-default ab-mb-1">目標進捗</h2>
             <p className="ab-text-body-s ab-text-secondary ab-mb-4">目標の入力状況</p>
-            <p className="ab-text-body-m ab-text-secondary">目標はまだ設定されていません</p>
+            {currentSheet ? (
+              <div className="ab-flex ab-flex-column ab-gap-2">
+                <p className="ab-text-body-m ab-text-default">
+                  登録目標数: {currentSheet.goalsCount}/6
+                </p>
+                <p className="ab-text-body-m ab-text-default">
+                  ウェイト合計: {currentSheet.totalWeight}%
+                </p>
+                <div
+                  style={{
+                    width: '100%',
+                    height: '8px',
+                    backgroundColor: '#e0e0e0',
+                    borderRadius: '4px',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${Math.min(currentSheet.totalWeight, 100)}%`,
+                      height: '100%',
+                      backgroundColor:
+                        currentSheet.totalWeight === 100 ? '#4caf50' : '#ff9800',
+                    }}
+                  />
+                </div>
+              </div>
+            ) : (
+              <p className="ab-text-body-m ab-text-secondary">目標はまだ設定されていません</p>
+            )}
           </div>
 
+          {/* 現在のフェーズ */}
           <div
             className="ab-bg-base ab-rounded-md ab-p-4"
             style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
           >
             <h2 className="ab-text-heading-m ab-text-default ab-mb-1">現在のフェーズ</h2>
             <p className="ab-text-body-s ab-text-secondary ab-mb-4">評価サイクルの状態</p>
-            <p className="ab-text-body-m ab-text-secondary">評価期間が設定されていません</p>
+            {currentSheet ? (
+              <div className="ab-flex ab-flex-column ab-gap-2">
+                <p className="ab-text-body-m ab-text-default">
+                  {phaseLabels[currentSheet.currentPhase]}
+                </p>
+                <p className="ab-text-body-s ab-text-secondary">
+                  {currentSheet.currentPhase === 'goal_setting' &&
+                    '目標を入力してください'}
+                  {currentSheet.currentPhase === 'goal_review' &&
+                    '目標の確定を待っています'}
+                  {currentSheet.currentPhase === 'self_evaluation' &&
+                    '自己評価を入力してください'}
+                  {currentSheet.currentPhase === 'self_confirmed' &&
+                    '自己評価の確定を待っています'}
+                  {currentSheet.currentPhase === 'manager_evaluation' &&
+                    '上長評価を待っています'}
+                  {currentSheet.currentPhase === 'manager_confirmed' &&
+                    '上長評価の確定を待っています'}
+                  {currentSheet.currentPhase === 'hr_evaluation' &&
+                    'HR判断を待っています'}
+                  {currentSheet.currentPhase === 'finalized' &&
+                    '評価が確定しました'}
+                </p>
+              </div>
+            ) : (
+              <p className="ab-text-body-m ab-text-secondary">評価期間が設定されていません</p>
+            )}
           </div>
+        </div>
+
+        {/* 過去の評価シート */}
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">過去の評価シート</h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">過去の評価期間のシート一覧</p>
+          <p className="ab-text-body-m ab-text-secondary">過去のシートはありません</p>
         </div>
       </div>
     </MainLayout>

--- a/src/app/sheet/[sheetId]/page.tsx
+++ b/src/app/sheet/[sheetId]/page.tsx
@@ -1,0 +1,125 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import { MainLayout } from '@/components/layout/main-layout';
+import { EvaluationSheetClient } from '@/components/sheet/evaluation-sheet-client';
+import { canEditSheet } from '@/lib/workflow';
+import type { EvaluationSheet } from '@/types/evaluation';
+import type { Role } from '@prisma/client';
+
+// モックデータ（データベース接続後に置き換え）
+function getMockSheet(sheetId: string): EvaluationSheet | null {
+  return {
+    id: sheetId,
+    userId: 'user-1',
+    periodId: 'period-1',
+    status: 'goal_setting',
+    user: {
+      id: 'user-1',
+      name: '山田 太郎',
+      email: 'yamada@example.com',
+      employeeNumber: 'EMP001',
+    },
+    period: {
+      id: 'period-1',
+      name: '2026年度上期',
+      year: 2026,
+      half: 'first',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-09-30'),
+      currentPhase: 'goal_setting',
+      isActive: true,
+    },
+    goals: [
+      {
+        id: 'goal-1',
+        sheetId: sheetId,
+        sortOrder: 1,
+        title: '新規顧客獲得数の増加',
+        description: '新規顧客を前期比120%獲得する',
+        achievementCriteria: '新規顧客獲得数が前期比120%以上',
+        weight: 30,
+        selfEvaluation: null,
+        managerEvaluation: null,
+      },
+      {
+        id: 'goal-2',
+        sheetId: sheetId,
+        sortOrder: 2,
+        title: 'チームの生産性向上',
+        description: 'チーム全体の生産性を15%向上させる',
+        achievementCriteria: '生産性指標が前期比115%以上',
+        weight: 25,
+        selfEvaluation: null,
+        managerEvaluation: null,
+      },
+      {
+        id: 'goal-3',
+        sheetId: sheetId,
+        sortOrder: 3,
+        title: '顧客満足度の維持・向上',
+        description: '顧客満足度調査でAランク以上を維持',
+        achievementCriteria: '顧客満足度調査で90点以上',
+        weight: 25,
+        selfEvaluation: null,
+        managerEvaluation: null,
+      },
+      {
+        id: 'goal-4',
+        sheetId: sheetId,
+        sortOrder: 4,
+        title: '業務プロセスの改善',
+        description: '業務効率化のための改善提案を3件以上実施',
+        achievementCriteria: '改善提案の採用数3件以上',
+        weight: 20,
+        selfEvaluation: null,
+        managerEvaluation: null,
+      },
+    ],
+    totalEvaluation: null,
+  };
+}
+
+interface PageProps {
+  params: Promise<{ sheetId: string }>;
+}
+
+export default async function SheetPage({ params }: PageProps) {
+  const session = await auth();
+  const { sheetId } = await params;
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  // モックデータを取得（データベース接続後に実際のクエリに置き換え）
+  const sheet = getMockSheet(sheetId);
+
+  if (!sheet) {
+    redirect('/dashboard');
+  }
+
+  const userRoles = (session.user.roles || ['employee']) as Role[];
+  const isOwner = sheet.userId === session.user.id || true; // モック用にtrueに
+  const isManager = userRoles.includes('manager');
+
+  // 編集権限を取得
+  const editPermissions = canEditSheet(
+    sheet.status,
+    sheet.period.currentPhase,
+    userRoles,
+    isOwner,
+    isManager
+  );
+
+  return (
+    <MainLayout>
+      <EvaluationSheetClient
+        sheet={sheet}
+        editPermissions={editPermissions}
+        userRoles={userRoles}
+        isOwner={isOwner}
+        isManager={isManager}
+      />
+    </MainLayout>
+  );
+}

--- a/src/components/sheet/evaluation-sheet-client.tsx
+++ b/src/components/sheet/evaluation-sheet-client.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import {
+  GoalCard,
+  GoalForm,
+  GoalFormOverlay,
+  SelfEvaluationForm,
+  ManagerEvaluationForm,
+  TotalEvaluationSection,
+  MgrJudgmentForm,
+  HrJudgmentForm,
+  WeightIndicator,
+} from '@/components/sheet';
+import type {
+  EvaluationSheet,
+  Goal,
+  GoalFormData,
+  SelfEvaluationFormData,
+  ManagerEvaluationFormData,
+  MgrJudgmentFormData,
+  HrJudgmentFormData,
+} from '@/types/evaluation';
+import { validateWeights, calculateAverageScore, halfLabels } from '@/types/evaluation';
+import { phaseLabels } from '@/lib/workflow';
+import type { Role } from '@prisma/client';
+
+interface EditPermissions {
+  canEditGoals: boolean;
+  canEditSelfEvaluation: boolean;
+  canEditManagerEvaluation: boolean;
+  canEditHrEvaluation: boolean;
+}
+
+interface EvaluationSheetClientProps {
+  sheet: EvaluationSheet;
+  editPermissions: EditPermissions;
+  userRoles: Role[];
+  isOwner: boolean;
+  isManager: boolean;
+}
+
+type ModalState =
+  | { type: 'none' }
+  | { type: 'goalForm'; goal: Goal | null }
+  | { type: 'selfEvaluation'; goal: Goal }
+  | { type: 'managerEvaluation'; goal: Goal }
+  | { type: 'mgrJudgment' }
+  | { type: 'hrJudgment' }
+  | { type: 'deleteConfirm'; goalId: string };
+
+export function EvaluationSheetClient({
+  sheet: initialSheet,
+  editPermissions,
+  userRoles,
+  isOwner,
+  isManager,
+}: EvaluationSheetClientProps) {
+  const [sheet, setSheet] = useState(initialSheet);
+  const [modalState, setModalState] = useState<ModalState>({ type: 'none' });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const weightValidation = validateWeights(sheet.goals);
+  const averageScore = calculateAverageScore(sheet.goals);
+
+  // 上長評価の表示権限（従業員本人には非表示）
+  const showManagerEvaluation = !isOwner || userRoles.includes('hr') || userRoles.includes('manager');
+
+  // Mgr判断の表示権限（従業員本人には非表示、管理職とHRには表示）
+  const showMgrJudgment = userRoles.includes('hr') || (userRoles.includes('manager') && !isOwner);
+
+  // HR判断の表示権限（HRと管理職には表示、従業員本人には非表示）
+  const showHrJudgment = userRoles.includes('hr') || (userRoles.includes('manager') && !isOwner);
+
+  // 目標追加・編集
+  const handleGoalSubmit = async (data: GoalFormData) => {
+    setIsLoading(true);
+    try {
+      const editingGoal = modalState.type === 'goalForm' ? modalState.goal : null;
+
+      if (editingGoal) {
+        // 更新
+        const updatedGoals = sheet.goals.map((g) =>
+          g.id === editingGoal.id
+            ? { ...g, ...data }
+            : g
+        );
+        setSheet({ ...sheet, goals: updatedGoals });
+      } else {
+        // 新規追加
+        const newGoal: Goal = {
+          id: `temp-${Date.now()}`,
+          sheetId: sheet.id,
+          sortOrder: sheet.goals.length + 1,
+          title: data.title,
+          description: data.description || null,
+          achievementCriteria: data.achievementCriteria || null,
+          weight: data.weight,
+          selfEvaluation: null,
+          managerEvaluation: null,
+        };
+        setSheet({ ...sheet, goals: [...sheet.goals, newGoal] });
+      }
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 目標削除
+  const handleGoalDelete = async (goalId: string) => {
+    setIsLoading(true);
+    try {
+      const updatedGoals = sheet.goals
+        .filter((g) => g.id !== goalId)
+        .map((g, index) => ({ ...g, sortOrder: index + 1 }));
+      setSheet({ ...sheet, goals: updatedGoals });
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 自己評価保存
+  const handleSelfEvaluationSubmit = async (goalId: string, data: SelfEvaluationFormData) => {
+    setIsLoading(true);
+    try {
+      const updatedGoals = sheet.goals.map((g) =>
+        g.id === goalId
+          ? {
+              ...g,
+              selfEvaluation: {
+                id: g.selfEvaluation?.id || `temp-self-${Date.now()}`,
+                goalId,
+                ...data,
+              },
+            }
+          : g
+      );
+      setSheet({ ...sheet, goals: updatedGoals });
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 上長評価保存
+  const handleManagerEvaluationSubmit = async (
+    goalId: string,
+    data: ManagerEvaluationFormData
+  ) => {
+    setIsLoading(true);
+    try {
+      const updatedGoals = sheet.goals.map((g) =>
+        g.id === goalId
+          ? {
+              ...g,
+              managerEvaluation: {
+                id: g.managerEvaluation?.id || `temp-mgr-${Date.now()}`,
+                goalId,
+                ...data,
+              },
+            }
+          : g
+      );
+      setSheet({ ...sheet, goals: updatedGoals });
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Mgr判断保存
+  const handleMgrJudgmentSubmit = async (data: MgrJudgmentFormData) => {
+    setIsLoading(true);
+    try {
+      setSheet({
+        ...sheet,
+        totalEvaluation: {
+          id: sheet.totalEvaluation?.id || `temp-total-${Date.now()}`,
+          sheetId: sheet.id,
+          averageScore: averageScore,
+          performanceComment: sheet.totalEvaluation?.performanceComment || null,
+          competencyLevel: data.competencyLevel,
+          competencyLevelReason: data.competencyLevelReason || null,
+          mgrTreatment: data.mgrTreatment,
+          mgrSalaryChange: data.mgrSalaryChange,
+          mgrTreatmentComment: data.mgrTreatmentComment || null,
+          mgrGrade: data.mgrGrade,
+          mgrGradeComment: data.mgrGradeComment || null,
+          hrTreatment: sheet.totalEvaluation?.hrTreatment || null,
+          hrSalaryChange: sheet.totalEvaluation?.hrSalaryChange || null,
+          hrGrade: sheet.totalEvaluation?.hrGrade || null,
+        },
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // HR判断保存
+  const handleHrJudgmentSubmit = async (data: HrJudgmentFormData) => {
+    setIsLoading(true);
+    try {
+      setSheet({
+        ...sheet,
+        totalEvaluation: {
+          ...sheet.totalEvaluation!,
+          hrTreatment: data.hrTreatment,
+          hrSalaryChange: data.hrSalaryChange,
+          hrGrade: data.hrGrade,
+        },
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="ab-flex ab-flex-column ab-gap-6">
+      {/* ヘッダー情報 */}
+      <div>
+        <div className="ab-flex ab-items-center ab-gap-4 ab-mb-2">
+          <h1 className="ab-text-heading-l ab-text-default">評価シート</h1>
+          <span
+            className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+            style={{ backgroundColor: '#1976d2', padding: '4px 12px' }}
+          >
+            {phaseLabels[sheet.status]}
+          </span>
+        </div>
+        <p className="ab-text-body-m ab-text-secondary">
+          {sheet.user.name} / {sheet.period.year}年 {halfLabels[sheet.period.half]}（
+          {sheet.period.name}）
+        </p>
+      </div>
+
+      {/* ウェイトインジケーター */}
+      {sheet.goals.length > 0 && <WeightIndicator validation={weightValidation} />}
+
+      {/* 目標一覧 */}
+      <div>
+        <div className="ab-flex ab-items-center ab-justify-between ab-mb-4">
+          <h2 className="ab-text-heading-m ab-text-default">
+            目標一覧（{sheet.goals.length}/6）
+          </h2>
+          {editPermissions.canEditGoals && sheet.goals.length < 6 && (
+            <Button
+              variant="default"
+              onClick={() => setModalState({ type: 'goalForm', goal: null })}
+            >
+              目標を追加
+            </Button>
+          )}
+        </div>
+
+        {sheet.goals.length === 0 ? (
+          <div
+            className="ab-bg-base ab-rounded-md ab-p-8 ab-text-center"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+          >
+            <p className="ab-text-body-m ab-text-secondary ab-mb-4">
+              まだ目標が登録されていません
+            </p>
+            {editPermissions.canEditGoals && (
+              <Button
+                variant="default"
+                onClick={() => setModalState({ type: 'goalForm', goal: null })}
+              >
+                最初の目標を追加
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="ab-flex ab-flex-column ab-gap-4">
+            {sheet.goals
+              .sort((a, b) => a.sortOrder - b.sortOrder)
+              .map((goal, index) => (
+                <GoalCard
+                  key={goal.id}
+                  goal={goal}
+                  index={index}
+                  canEditGoal={editPermissions.canEditGoals}
+                  canEditSelfEvaluation={editPermissions.canEditSelfEvaluation}
+                  canEditManagerEvaluation={editPermissions.canEditManagerEvaluation}
+                  showManagerEvaluation={showManagerEvaluation}
+                  onEdit={(g) => setModalState({ type: 'goalForm', goal: g })}
+                  onDelete={(id) => setModalState({ type: 'deleteConfirm', goalId: id })}
+                  onEditSelfEvaluation={(g) =>
+                    setModalState({ type: 'selfEvaluation', goal: g })
+                  }
+                  onEditManagerEvaluation={(g) =>
+                    setModalState({ type: 'managerEvaluation', goal: g })
+                  }
+                />
+              ))}
+          </div>
+        )}
+      </div>
+
+      {/* 総評セクション */}
+      <TotalEvaluationSection
+        totalEvaluation={sheet.totalEvaluation}
+        averageScore={averageScore}
+        canEditMgrJudgment={editPermissions.canEditManagerEvaluation}
+        canEditHrJudgment={editPermissions.canEditHrEvaluation}
+        showMgrJudgment={showMgrJudgment}
+        showHrJudgment={showHrJudgment}
+        onEditMgrJudgment={() => setModalState({ type: 'mgrJudgment' })}
+        onEditHrJudgment={() => setModalState({ type: 'hrJudgment' })}
+      />
+
+      {/* モーダル */}
+      {modalState.type !== 'none' && (
+        <GoalFormOverlay onClose={() => setModalState({ type: 'none' })} />
+      )}
+
+      {modalState.type === 'goalForm' && (
+        <GoalForm
+          goal={modalState.goal}
+          onSubmit={handleGoalSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={isLoading}
+        />
+      )}
+
+      {modalState.type === 'selfEvaluation' && (
+        <SelfEvaluationForm
+          goal={modalState.goal}
+          onSubmit={handleSelfEvaluationSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={isLoading}
+        />
+      )}
+
+      {modalState.type === 'managerEvaluation' && (
+        <ManagerEvaluationForm
+          goal={modalState.goal}
+          onSubmit={handleManagerEvaluationSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={isLoading}
+        />
+      )}
+
+      {modalState.type === 'mgrJudgment' && (
+        <MgrJudgmentForm
+          totalEvaluation={sheet.totalEvaluation}
+          onSubmit={handleMgrJudgmentSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={isLoading}
+        />
+      )}
+
+      {modalState.type === 'hrJudgment' && (
+        <HrJudgmentForm
+          totalEvaluation={sheet.totalEvaluation}
+          onSubmit={handleHrJudgmentSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={isLoading}
+        />
+      )}
+
+      {modalState.type === 'deleteConfirm' && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-6"
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '90%',
+            maxWidth: '400px',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+            zIndex: 1000,
+          }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-2">目標の削除</h2>
+          <p className="ab-text-body-m ab-text-secondary ab-mb-4">
+            この目標を削除してもよろしいですか？この操作は取り消せません。
+          </p>
+          <div className="ab-flex ab-gap-2 ab-justify-end">
+            <Button
+              variant="outlined"
+              onClick={() => setModalState({ type: 'none' })}
+              disabled={isLoading}
+            >
+              キャンセル
+            </Button>
+            <Button
+              variant="negative"
+              onClick={() => handleGoalDelete(modalState.goalId)}
+              disabled={isLoading}
+            >
+              {isLoading ? '削除中...' : '削除'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sheet/goal-card.tsx
+++ b/src/components/sheet/goal-card.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import type { Goal } from '@/types/evaluation';
+import {
+  performanceRatingLabels,
+  competencyRatingLabels,
+} from '@/types/evaluation';
+
+interface GoalCardProps {
+  goal: Goal;
+  index: number;
+  canEditGoal: boolean;
+  canEditSelfEvaluation: boolean;
+  canEditManagerEvaluation: boolean;
+  showManagerEvaluation: boolean;
+  onEdit?: (goal: Goal) => void;
+  onDelete?: (goalId: string) => void;
+  onEditSelfEvaluation?: (goal: Goal) => void;
+  onEditManagerEvaluation?: (goal: Goal) => void;
+}
+
+export function GoalCard({
+  goal,
+  index,
+  canEditGoal,
+  canEditSelfEvaluation,
+  canEditManagerEvaluation,
+  showManagerEvaluation,
+  onEdit,
+  onDelete,
+  onEditSelfEvaluation,
+  onEditManagerEvaluation,
+}: GoalCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-4"
+      style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+    >
+      {/* ヘッダー */}
+      <div className="ab-flex ab-items-start ab-gap-4">
+        <div
+          className="ab-flex ab-items-center ab-justify-center ab-rounded-full ab-bg-rest-primary ab-text-on-primary"
+          style={{ width: '32px', height: '32px', flexShrink: 0 }}
+        >
+          {index + 1}
+        </div>
+
+        <div style={{ flex: 1 }}>
+          <div className="ab-flex ab-items-center ab-gap-2 ab-mb-1">
+            <h3 className="ab-text-heading-s ab-text-default">{goal.title}</h3>
+            <span
+              className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+              style={{
+                backgroundColor: '#1976d2',
+                padding: '2px 8px',
+              }}
+            >
+              {goal.weight}%
+            </span>
+          </div>
+
+          {goal.description && (
+            <p className="ab-text-body-s ab-text-secondary ab-mb-2">{goal.description}</p>
+          )}
+
+          {goal.achievementCriteria && (
+            <div className="ab-mb-2">
+              <span className="ab-text-body-s ab-text-secondary">達成基準: </span>
+              <span className="ab-text-body-s ab-text-default">{goal.achievementCriteria}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="ab-flex ab-items-center ab-gap-2">
+          {canEditGoal && (
+            <>
+              <Button variant="outlined" size="small" onClick={() => onEdit?.(goal)}>
+                編集
+              </Button>
+              <Button variant="outlined" size="small" onClick={() => onDelete?.(goal.id)}>
+                削除
+              </Button>
+            </>
+          )}
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => setIsExpanded(!isExpanded)}
+          >
+            {isExpanded ? '閉じる' : '詳細'}
+          </Button>
+        </div>
+      </div>
+
+      {/* 詳細（展開時） */}
+      {isExpanded && (
+        <div className="ab-mt-4" style={{ borderTop: '1px solid #e0e0e0', paddingTop: '16px' }}>
+          {/* 自己評価セクション */}
+          <div className="ab-mb-4">
+            <div className="ab-flex ab-items-center ab-justify-between ab-mb-2">
+              <h4 className="ab-text-heading-xs ab-text-default">自己評価</h4>
+              {canEditSelfEvaluation && (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => onEditSelfEvaluation?.(goal)}
+                >
+                  {goal.selfEvaluation ? '編集' : '入力'}
+                </Button>
+              )}
+            </div>
+
+            {goal.selfEvaluation ? (
+              <div className="ab-flex ab-flex-column ab-gap-3">
+                <div>
+                  <p className="ab-text-body-s ab-text-secondary ab-mb-1">成果振り返り</p>
+                  <p className="ab-text-body-m ab-text-default">
+                    {goal.selfEvaluation.performanceReflection || '未入力'}
+                  </p>
+                </div>
+
+                <div>
+                  <p className="ab-text-body-s ab-text-secondary ab-mb-1">成果評価</p>
+                  <p className="ab-text-body-m ab-text-default">
+                    {goal.selfEvaluation.performanceRating
+                      ? performanceRatingLabels[goal.selfEvaluation.performanceRating]
+                      : '未入力'}
+                  </p>
+                </div>
+
+                <div>
+                  <p className="ab-text-body-s ab-text-secondary ab-mb-1">
+                    コンピテンシー振り返り
+                  </p>
+                  <ul style={{ paddingLeft: '20px', margin: 0 }}>
+                    <li className="ab-text-body-m ab-text-default">
+                      {goal.selfEvaluation.competencyReflection1 || '未入力'}
+                    </li>
+                    <li className="ab-text-body-m ab-text-default">
+                      {goal.selfEvaluation.competencyReflection2 || '未入力'}
+                    </li>
+                    <li className="ab-text-body-m ab-text-default">
+                      {goal.selfEvaluation.competencyReflection3 || '未入力'}
+                    </li>
+                  </ul>
+                </div>
+
+                <div>
+                  <p className="ab-text-body-s ab-text-secondary ab-mb-1">コンピテンシー評価</p>
+                  <p className="ab-text-body-m ab-text-default">
+                    {goal.selfEvaluation.competencyRating
+                      ? competencyRatingLabels[goal.selfEvaluation.competencyRating]
+                      : '未入力'}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <p className="ab-text-body-m ab-text-secondary">自己評価は未入力です</p>
+            )}
+          </div>
+
+          {/* 上長評価セクション（表示権限がある場合のみ） */}
+          {showManagerEvaluation && (
+            <div style={{ borderTop: '1px solid #e0e0e0', paddingTop: '16px' }}>
+              <div className="ab-flex ab-items-center ab-justify-between ab-mb-2">
+                <h4 className="ab-text-heading-xs ab-text-default">上長評価</h4>
+                {canEditManagerEvaluation && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => onEditManagerEvaluation?.(goal)}
+                  >
+                    {goal.managerEvaluation ? '編集' : '入力'}
+                  </Button>
+                )}
+              </div>
+
+              {goal.managerEvaluation ? (
+                <div className="ab-flex ab-flex-column ab-gap-3">
+                  <div>
+                    <p className="ab-text-body-s ab-text-secondary ab-mb-1">成果コメント</p>
+                    <p className="ab-text-body-m ab-text-default">
+                      {goal.managerEvaluation.performanceComment || '未入力'}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="ab-text-body-s ab-text-secondary ab-mb-1">成果評価</p>
+                    <p className="ab-text-body-m ab-text-default">
+                      {goal.managerEvaluation.performanceRating
+                        ? performanceRatingLabels[goal.managerEvaluation.performanceRating]
+                        : '未入力'}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="ab-text-body-s ab-text-secondary ab-mb-1">
+                      コンピテンシーコメント
+                    </p>
+                    <p className="ab-text-body-m ab-text-default">
+                      {goal.managerEvaluation.competencyComment || '未入力'}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="ab-text-body-s ab-text-secondary ab-mb-1">コンピテンシー評価</p>
+                    <p className="ab-text-body-m ab-text-default">
+                      {goal.managerEvaluation.competencyRating
+                        ? competencyRatingLabels[goal.managerEvaluation.competencyRating]
+                        : '未入力'}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <p className="ab-text-body-m ab-text-secondary">上長評価は未入力です</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sheet/goal-form.tsx
+++ b/src/components/sheet/goal-form.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button, Textfield } from '@giftee/abukuma-react';
+import type { Goal, GoalFormData } from '@/types/evaluation';
+
+interface GoalFormProps {
+  goal?: Goal | null;
+  onSubmit: (data: GoalFormData) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function GoalForm({ goal, onSubmit, onCancel, isLoading = false }: GoalFormProps) {
+  const [formData, setFormData] = useState<GoalFormData>({
+    title: '',
+    description: '',
+    achievementCriteria: '',
+    weight: 20,
+  });
+  const [errors, setErrors] = useState<Partial<Record<keyof GoalFormData, string>>>({});
+
+  useEffect(() => {
+    if (goal) {
+      setFormData({
+        title: goal.title,
+        description: goal.description || '',
+        achievementCriteria: goal.achievementCriteria || '',
+        weight: goal.weight,
+      });
+    }
+  }, [goal]);
+
+  const validate = (): boolean => {
+    const newErrors: Partial<Record<keyof GoalFormData, string>> = {};
+
+    if (!formData.title.trim()) {
+      newErrors.title = '目標概要は必須です';
+    }
+
+    if (formData.weight < 1 || formData.weight > 40) {
+      newErrors.weight = 'ウェイトは1%〜40%の範囲で設定してください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validate()) {
+      onSubmit(formData);
+    }
+  };
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-6"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '90%',
+        maxWidth: '600px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+        zIndex: 1000,
+      }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-4">
+        {goal ? '目標を編集' : '目標を追加'}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="ab-flex ab-flex-column ab-gap-4">
+        <div>
+          <Textfield
+            label="目標概要"
+            value={formData.title}
+            onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+            placeholder="目標の概要を入力してください"
+            disabled={isLoading}
+          />
+          {errors.title && (
+            <p className="ab-text-body-s ab-mt-1" style={{ color: '#f44336' }}>
+              {errors.title}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            目標詳細
+          </label>
+          <textarea
+            value={formData.description}
+            onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            placeholder="目標の詳細を入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '100px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            達成基準
+          </label>
+          <textarea
+            value={formData.achievementCriteria}
+            onChange={(e) => setFormData({ ...formData, achievementCriteria: e.target.value })}
+            placeholder="達成基準を入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '80px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            ウェイト (%)
+          </label>
+          <input
+            type="number"
+            value={formData.weight}
+            onChange={(e) =>
+              setFormData({ ...formData, weight: parseInt(e.target.value) || 0 })
+            }
+            min={1}
+            max={40}
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+            }}
+          />
+          {errors.weight && (
+            <p className="ab-text-body-s ab-mt-1" style={{ color: '#f44336' }}>
+              {errors.weight}
+            </p>
+          )}
+          <p className="ab-text-body-s ab-text-secondary ab-mt-1">
+            1目標あたり最大40%まで設定できます
+          </p>
+        </div>
+
+        <div className="ab-flex ab-gap-2 ab-justify-end ab-mt-4">
+          <Button variant="outlined" onClick={onCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="default" disabled={isLoading}>
+            {isLoading ? '保存中...' : goal ? '更新' : '追加'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// オーバーレイ
+export function GoalFormOverlay({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        zIndex: 999,
+      }}
+    />
+  );
+}

--- a/src/components/sheet/index.ts
+++ b/src/components/sheet/index.ts
@@ -1,0 +1,7 @@
+export { GoalCard } from './goal-card';
+export { GoalForm, GoalFormOverlay } from './goal-form';
+export { SelfEvaluationForm } from './self-evaluation-form';
+export { ManagerEvaluationForm } from './manager-evaluation-form';
+export { TotalEvaluationSection, MgrJudgmentForm, HrJudgmentForm } from './total-evaluation';
+export { WeightIndicator } from './weight-indicator';
+export { EvaluationSheetClient } from './evaluation-sheet-client';

--- a/src/components/sheet/manager-evaluation-form.tsx
+++ b/src/components/sheet/manager-evaluation-form.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import type { Goal, ManagerEvaluationFormData } from '@/types/evaluation';
+import { performanceRatingLabels, competencyRatingLabels } from '@/types/evaluation';
+import { PerformanceRating, CompetencyRating } from '@prisma/client';
+
+interface ManagerEvaluationFormProps {
+  goal: Goal;
+  onSubmit: (goalId: string, data: ManagerEvaluationFormData) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function ManagerEvaluationForm({
+  goal,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: ManagerEvaluationFormProps) {
+  const [formData, setFormData] = useState<ManagerEvaluationFormData>({
+    performanceComment: '',
+    performanceRating: null,
+    competencyComment: '',
+    competencyRating: null,
+  });
+
+  useEffect(() => {
+    if (goal.managerEvaluation) {
+      setFormData({
+        performanceComment: goal.managerEvaluation.performanceComment || '',
+        performanceRating: goal.managerEvaluation.performanceRating,
+        competencyComment: goal.managerEvaluation.competencyComment || '',
+        competencyRating: goal.managerEvaluation.competencyRating,
+      });
+    }
+  }, [goal]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(goal.id, formData);
+  };
+
+  const performanceRatings = Object.keys(performanceRatingLabels) as PerformanceRating[];
+  const competencyRatings = Object.keys(competencyRatingLabels) as CompetencyRating[];
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-6"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '90%',
+        maxWidth: '700px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+        zIndex: 1000,
+      }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-2">上長評価</h2>
+      <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+        目標: {goal.title}
+      </p>
+
+      {/* 自己評価の参照表示 */}
+      {goal.selfEvaluation && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4 ab-mb-4"
+          style={{ backgroundColor: '#f5f5f5' }}
+        >
+          <h3 className="ab-text-heading-xs ab-text-default ab-mb-2">自己評価（参照）</h3>
+          <div className="ab-flex ab-flex-column ab-gap-2">
+            <div>
+              <span className="ab-text-body-s ab-text-secondary">成果振り返り: </span>
+              <span className="ab-text-body-s ab-text-default">
+                {goal.selfEvaluation.performanceReflection || '未入力'}
+              </span>
+            </div>
+            <div>
+              <span className="ab-text-body-s ab-text-secondary">自己評価: </span>
+              <span className="ab-text-body-s ab-text-default">
+                {goal.selfEvaluation.performanceRating
+                  ? performanceRatingLabels[goal.selfEvaluation.performanceRating]
+                  : '未入力'}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="ab-flex ab-flex-column ab-gap-4">
+        {/* 成果コメント */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            成果コメント
+          </label>
+          <textarea
+            value={formData.performanceComment}
+            onChange={(e) =>
+              setFormData({ ...formData, performanceComment: e.target.value })
+            }
+            placeholder="成果に対するコメントを入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '120px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        {/* 成果評価 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            成果評価
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {performanceRatings.map((rating) => (
+              <button
+                key={rating}
+                type="button"
+                onClick={() => setFormData({ ...formData, performanceRating: rating })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.performanceRating === rating ? '#1976d2' : 'white',
+                  color: formData.performanceRating === rating ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {performanceRatingLabels[rating]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* コンピテンシーコメント */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            コンピテンシーコメント
+          </label>
+          <textarea
+            value={formData.competencyComment}
+            onChange={(e) =>
+              setFormData({ ...formData, competencyComment: e.target.value })
+            }
+            placeholder="コンピテンシーに対するコメントを入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '100px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        {/* コンピテンシー評価 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            コンピテンシー評価
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {competencyRatings.map((rating) => (
+              <button
+                key={rating}
+                type="button"
+                onClick={() => setFormData({ ...formData, competencyRating: rating })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.competencyRating === rating ? '#1976d2' : 'white',
+                  color: formData.competencyRating === rating ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {competencyRatingLabels[rating]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ab-flex ab-gap-2 ab-justify-end ab-mt-4">
+          <Button variant="outlined" onClick={onCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="default" disabled={isLoading}>
+            {isLoading ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/sheet/self-evaluation-form.tsx
+++ b/src/components/sheet/self-evaluation-form.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import type { Goal, SelfEvaluationFormData } from '@/types/evaluation';
+import { performanceRatingLabels, competencyRatingLabels } from '@/types/evaluation';
+import { PerformanceRating, CompetencyRating } from '@prisma/client';
+
+interface SelfEvaluationFormProps {
+  goal: Goal;
+  onSubmit: (goalId: string, data: SelfEvaluationFormData) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function SelfEvaluationForm({
+  goal,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: SelfEvaluationFormProps) {
+  const [formData, setFormData] = useState<SelfEvaluationFormData>({
+    performanceReflection: '',
+    performanceRating: null,
+    competencyReflection1: '',
+    competencyReflection2: '',
+    competencyReflection3: '',
+    competencyRating: null,
+  });
+
+  useEffect(() => {
+    if (goal.selfEvaluation) {
+      setFormData({
+        performanceReflection: goal.selfEvaluation.performanceReflection || '',
+        performanceRating: goal.selfEvaluation.performanceRating,
+        competencyReflection1: goal.selfEvaluation.competencyReflection1 || '',
+        competencyReflection2: goal.selfEvaluation.competencyReflection2 || '',
+        competencyReflection3: goal.selfEvaluation.competencyReflection3 || '',
+        competencyRating: goal.selfEvaluation.competencyRating,
+      });
+    }
+  }, [goal]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(goal.id, formData);
+  };
+
+  const performanceRatings = Object.keys(performanceRatingLabels) as PerformanceRating[];
+  const competencyRatings = Object.keys(competencyRatingLabels) as CompetencyRating[];
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-6"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '90%',
+        maxWidth: '700px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+        zIndex: 1000,
+      }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-2">自己評価</h2>
+      <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+        目標: {goal.title}
+      </p>
+
+      <form onSubmit={handleSubmit} className="ab-flex ab-flex-column ab-gap-4">
+        {/* 成果振り返り */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            成果振り返り
+          </label>
+          <textarea
+            value={formData.performanceReflection}
+            onChange={(e) =>
+              setFormData({ ...formData, performanceReflection: e.target.value })
+            }
+            placeholder="この期間の成果を振り返って記入してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '120px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        {/* 成果評価 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            成果評価
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {performanceRatings.map((rating) => (
+              <button
+                key={rating}
+                type="button"
+                onClick={() => setFormData({ ...formData, performanceRating: rating })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.performanceRating === rating ? '#1976d2' : 'white',
+                  color: formData.performanceRating === rating ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {performanceRatingLabels[rating]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* コンピテンシー振り返り */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            コンピテンシー振り返り（3項目）
+          </label>
+          <div className="ab-flex ab-flex-column ab-gap-2">
+            <textarea
+              value={formData.competencyReflection1}
+              onChange={(e) =>
+                setFormData({ ...formData, competencyReflection1: e.target.value })
+              }
+              placeholder="コンピテンシー振り返り 1"
+              disabled={isLoading}
+              className="ab-text-body-m"
+              style={{
+                width: '100%',
+                minHeight: '80px',
+                padding: '12px',
+                border: '1px solid #e0e0e0',
+                borderRadius: '4px',
+                resize: 'vertical',
+                fontFamily: 'inherit',
+              }}
+            />
+            <textarea
+              value={formData.competencyReflection2}
+              onChange={(e) =>
+                setFormData({ ...formData, competencyReflection2: e.target.value })
+              }
+              placeholder="コンピテンシー振り返り 2"
+              disabled={isLoading}
+              className="ab-text-body-m"
+              style={{
+                width: '100%',
+                minHeight: '80px',
+                padding: '12px',
+                border: '1px solid #e0e0e0',
+                borderRadius: '4px',
+                resize: 'vertical',
+                fontFamily: 'inherit',
+              }}
+            />
+            <textarea
+              value={formData.competencyReflection3}
+              onChange={(e) =>
+                setFormData({ ...formData, competencyReflection3: e.target.value })
+              }
+              placeholder="コンピテンシー振り返り 3"
+              disabled={isLoading}
+              className="ab-text-body-m"
+              style={{
+                width: '100%',
+                minHeight: '80px',
+                padding: '12px',
+                border: '1px solid #e0e0e0',
+                borderRadius: '4px',
+                resize: 'vertical',
+                fontFamily: 'inherit',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* コンピテンシー評価 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            コンピテンシー評価
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {competencyRatings.map((rating) => (
+              <button
+                key={rating}
+                type="button"
+                onClick={() => setFormData({ ...formData, competencyRating: rating })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.competencyRating === rating ? '#1976d2' : 'white',
+                  color: formData.competencyRating === rating ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {competencyRatingLabels[rating]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ab-flex ab-gap-2 ab-justify-end ab-mt-4">
+          <Button variant="outlined" onClick={onCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="default" disabled={isLoading}>
+            {isLoading ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/sheet/total-evaluation.tsx
+++ b/src/components/sheet/total-evaluation.tsx
@@ -1,0 +1,555 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import type { TotalEvaluation, MgrJudgmentFormData, HrJudgmentFormData } from '@/types/evaluation';
+import {
+  competencyRatingLabels,
+  gradeLabels,
+  treatmentLabels,
+} from '@/types/evaluation';
+import { CompetencyRating, Grade, Treatment } from '@prisma/client';
+
+interface TotalEvaluationSectionProps {
+  totalEvaluation: TotalEvaluation | null;
+  averageScore: number | null;
+  canEditMgrJudgment: boolean;
+  canEditHrJudgment: boolean;
+  showMgrJudgment: boolean;
+  showHrJudgment: boolean;
+  onEditMgrJudgment?: () => void;
+  onEditHrJudgment?: () => void;
+}
+
+export function TotalEvaluationSection({
+  totalEvaluation,
+  averageScore,
+  canEditMgrJudgment,
+  canEditHrJudgment,
+  showMgrJudgment,
+  showHrJudgment,
+  onEditMgrJudgment,
+  onEditHrJudgment,
+}: TotalEvaluationSectionProps) {
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-4"
+      style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-4">総評</h2>
+
+      <div className="ab-flex ab-flex-column ab-gap-4">
+        {/* 平均点 */}
+        <div
+          className="ab-rounded-md ab-p-4"
+          style={{ backgroundColor: '#f5f5f5' }}
+        >
+          <div className="ab-flex ab-items-center ab-justify-between">
+            <span className="ab-text-body-m ab-text-secondary">平均点（自動計算）</span>
+            <span className="ab-text-heading-l ab-text-default">
+              {averageScore !== null ? averageScore.toFixed(2) : '-'}
+            </span>
+          </div>
+        </div>
+
+        {/* コンピテンシーレベル */}
+        <div>
+          <div className="ab-flex ab-items-center ab-justify-between ab-mb-2">
+            <span className="ab-text-body-m ab-text-secondary">コンピテンシーレベル</span>
+            <span className="ab-text-body-m ab-text-default">
+              {totalEvaluation?.competencyLevel
+                ? competencyRatingLabels[totalEvaluation.competencyLevel]
+                : '-'}
+            </span>
+          </div>
+          {totalEvaluation?.competencyLevelReason && (
+            <p className="ab-text-body-s ab-text-secondary">
+              理由: {totalEvaluation.competencyLevelReason}
+            </p>
+          )}
+        </div>
+
+        {/* Mgr判断 */}
+        {showMgrJudgment && (
+          <div style={{ borderTop: '1px solid #e0e0e0', paddingTop: '16px' }}>
+            <div className="ab-flex ab-items-center ab-justify-between ab-mb-3">
+              <h3 className="ab-text-heading-s ab-text-default">Mgr判断</h3>
+              {canEditMgrJudgment && (
+                <Button variant="outlined" size="small" onClick={onEditMgrJudgment}>
+                  {totalEvaluation?.mgrTreatment ? '編集' : '入力'}
+                </Button>
+              )}
+            </div>
+
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">処置</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.mgrTreatment
+                    ? treatmentLabels[totalEvaluation.mgrTreatment]
+                    : '-'}
+                </span>
+              </div>
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">昇給額</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.mgrSalaryChange != null
+                    ? `${totalEvaluation!.mgrSalaryChange!.toLocaleString()}円`
+                    : '-'}
+                </span>
+              </div>
+              {totalEvaluation?.mgrTreatmentComment && (
+                <div>
+                  <span className="ab-text-body-s ab-text-secondary">コメント: </span>
+                  <span className="ab-text-body-s ab-text-default">
+                    {totalEvaluation.mgrTreatmentComment}
+                  </span>
+                </div>
+              )}
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">等級</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.mgrGrade ? gradeLabels[totalEvaluation.mgrGrade] : '-'}
+                </span>
+              </div>
+              {totalEvaluation?.mgrGradeComment && (
+                <div>
+                  <span className="ab-text-body-s ab-text-secondary">等級コメント: </span>
+                  <span className="ab-text-body-s ab-text-default">
+                    {totalEvaluation.mgrGradeComment}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* HR判断 */}
+        {showHrJudgment && (
+          <div style={{ borderTop: '1px solid #e0e0e0', paddingTop: '16px' }}>
+            <div className="ab-flex ab-items-center ab-justify-between ab-mb-3">
+              <h3 className="ab-text-heading-s ab-text-default">HR判断</h3>
+              {canEditHrJudgment && (
+                <Button variant="outlined" size="small" onClick={onEditHrJudgment}>
+                  {totalEvaluation?.hrTreatment ? '編集' : '入力'}
+                </Button>
+              )}
+            </div>
+
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">最終処置</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.hrTreatment
+                    ? treatmentLabels[totalEvaluation.hrTreatment]
+                    : '-'}
+                </span>
+              </div>
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">最終昇給額</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.hrSalaryChange != null
+                    ? `${totalEvaluation!.hrSalaryChange!.toLocaleString()}円`
+                    : '-'}
+                </span>
+              </div>
+              <div className="ab-flex ab-items-center ab-justify-between">
+                <span className="ab-text-body-s ab-text-secondary">最終等級</span>
+                <span className="ab-text-body-m ab-text-default">
+                  {totalEvaluation?.hrGrade ? gradeLabels[totalEvaluation.hrGrade] : '-'}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Mgr判断フォーム
+interface MgrJudgmentFormProps {
+  totalEvaluation: TotalEvaluation | null;
+  onSubmit: (data: MgrJudgmentFormData) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function MgrJudgmentForm({
+  totalEvaluation,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: MgrJudgmentFormProps) {
+  const [formData, setFormData] = useState<MgrJudgmentFormData>({
+    competencyLevel: totalEvaluation?.competencyLevel || null,
+    competencyLevelReason: totalEvaluation?.competencyLevelReason || '',
+    mgrTreatment: totalEvaluation?.mgrTreatment || null,
+    mgrSalaryChange: totalEvaluation?.mgrSalaryChange || null,
+    mgrTreatmentComment: totalEvaluation?.mgrTreatmentComment || '',
+    mgrGrade: totalEvaluation?.mgrGrade || null,
+    mgrGradeComment: totalEvaluation?.mgrGradeComment || '',
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  const competencyRatings = Object.keys(competencyRatingLabels) as CompetencyRating[];
+  const treatments = Object.keys(treatmentLabels) as Treatment[];
+  const grades = Object.keys(gradeLabels) as Grade[];
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-6"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '90%',
+        maxWidth: '600px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+        zIndex: 1000,
+      }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-4">Mgr判断</h2>
+
+      <form onSubmit={handleSubmit} className="ab-flex ab-flex-column ab-gap-4">
+        {/* コンピテンシーレベル */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            コンピテンシーレベル
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {competencyRatings.map((rating) => (
+              <button
+                key={rating}
+                type="button"
+                onClick={() => setFormData({ ...formData, competencyLevel: rating })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.competencyLevel === rating ? '#1976d2' : 'white',
+                  color: formData.competencyLevel === rating ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {competencyRatingLabels[rating]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            コンピテンシーレベル理由
+          </label>
+          <textarea
+            value={formData.competencyLevelReason}
+            onChange={(e) =>
+              setFormData({ ...formData, competencyLevelReason: e.target.value })
+            }
+            placeholder="理由を入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '80px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        {/* 処置 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            処置
+          </label>
+          <div className="ab-flex ab-gap-2">
+            {treatments.map((treatment) => (
+              <button
+                key={treatment}
+                type="button"
+                onClick={() => setFormData({ ...formData, mgrTreatment: treatment })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.mgrTreatment === treatment ? '#1976d2' : 'white',
+                  color: formData.mgrTreatment === treatment ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {treatmentLabels[treatment]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 昇給額 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            昇給額 (円)
+          </label>
+          <input
+            type="number"
+            value={formData.mgrSalaryChange || ''}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                mgrSalaryChange: e.target.value ? parseInt(e.target.value) : null,
+              })
+            }
+            placeholder="0"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '150px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+            }}
+          />
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            処置コメント
+          </label>
+          <textarea
+            value={formData.mgrTreatmentComment}
+            onChange={(e) =>
+              setFormData({ ...formData, mgrTreatmentComment: e.target.value })
+            }
+            placeholder="コメントを入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '80px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        {/* 等級 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            等級
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {grades.map((grade) => (
+              <button
+                key={grade}
+                type="button"
+                onClick={() => setFormData({ ...formData, mgrGrade: grade })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor: formData.mgrGrade === grade ? '#1976d2' : 'white',
+                  color: formData.mgrGrade === grade ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {gradeLabels[grade]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            等級コメント
+          </label>
+          <textarea
+            value={formData.mgrGradeComment}
+            onChange={(e) =>
+              setFormData({ ...formData, mgrGradeComment: e.target.value })
+            }
+            placeholder="コメントを入力してください"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '100%',
+              minHeight: '80px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+            }}
+          />
+        </div>
+
+        <div className="ab-flex ab-gap-2 ab-justify-end ab-mt-4">
+          <Button variant="outlined" onClick={onCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="default" disabled={isLoading}>
+            {isLoading ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// HR判断フォーム
+interface HrJudgmentFormProps {
+  totalEvaluation: TotalEvaluation | null;
+  onSubmit: (data: HrJudgmentFormData) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function HrJudgmentForm({
+  totalEvaluation,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: HrJudgmentFormProps) {
+  const [formData, setFormData] = useState<HrJudgmentFormData>({
+    hrTreatment: totalEvaluation?.hrTreatment || null,
+    hrSalaryChange: totalEvaluation?.hrSalaryChange || null,
+    hrGrade: totalEvaluation?.hrGrade || null,
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+  const treatments = Object.keys(treatmentLabels) as Treatment[];
+  const grades = Object.keys(gradeLabels) as Grade[];
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-6"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '90%',
+        maxWidth: '500px',
+        maxHeight: '90vh',
+        overflow: 'auto',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+        zIndex: 1000,
+      }}
+    >
+      <h2 className="ab-text-heading-m ab-text-default ab-mb-4">HR判断</h2>
+
+      <form onSubmit={handleSubmit} className="ab-flex ab-flex-column ab-gap-4">
+        {/* 最終処置 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            最終処置
+          </label>
+          <div className="ab-flex ab-gap-2">
+            {treatments.map((treatment) => (
+              <button
+                key={treatment}
+                type="button"
+                onClick={() => setFormData({ ...formData, hrTreatment: treatment })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor:
+                    formData.hrTreatment === treatment ? '#1976d2' : 'white',
+                  color: formData.hrTreatment === treatment ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {treatmentLabels[treatment]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 最終昇給額 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-1" style={{ display: 'block' }}>
+            最終昇給額 (円)
+          </label>
+          <input
+            type="number"
+            value={formData.hrSalaryChange || ''}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                hrSalaryChange: e.target.value ? parseInt(e.target.value) : null,
+              })
+            }
+            placeholder="0"
+            disabled={isLoading}
+            className="ab-text-body-m"
+            style={{
+              width: '150px',
+              padding: '12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: '4px',
+            }}
+          />
+        </div>
+
+        {/* 最終等級 */}
+        <div>
+          <label className="ab-text-body-s ab-text-secondary ab-mb-2" style={{ display: 'block' }}>
+            最終等級
+          </label>
+          <div className="ab-flex ab-gap-2 ab-flex-wrap">
+            {grades.map((grade) => (
+              <button
+                key={grade}
+                type="button"
+                onClick={() => setFormData({ ...formData, hrGrade: grade })}
+                disabled={isLoading}
+                className="ab-text-body-m ab-rounded-md"
+                style={{
+                  padding: '8px 16px',
+                  border: '1px solid #e0e0e0',
+                  backgroundColor: formData.hrGrade === grade ? '#1976d2' : 'white',
+                  color: formData.hrGrade === grade ? 'white' : '#333',
+                  cursor: 'pointer',
+                }}
+              >
+                {gradeLabels[grade]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="ab-flex ab-gap-2 ab-justify-end ab-mt-4">
+          <Button variant="outlined" onClick={onCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button type="submit" variant="default" disabled={isLoading}>
+            {isLoading ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/sheet/weight-indicator.tsx
+++ b/src/components/sheet/weight-indicator.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { WeightValidation } from '@/types/evaluation';
+
+interface WeightIndicatorProps {
+  validation: WeightValidation;
+}
+
+export function WeightIndicator({ validation }: WeightIndicatorProps) {
+  const { isValid, totalWeight, errors } = validation;
+
+  return (
+    <div
+      className="ab-bg-base ab-rounded-md ab-p-4"
+      style={{
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+        borderLeft: `4px solid ${isValid ? '#4caf50' : '#f44336'}`,
+      }}
+    >
+      <div className="ab-flex ab-items-center ab-justify-between ab-mb-2">
+        <span className="ab-text-heading-xs ab-text-default">ウェイト合計</span>
+        <span
+          className="ab-text-heading-m"
+          style={{ color: isValid ? '#4caf50' : '#f44336' }}
+        >
+          {totalWeight}%
+        </span>
+      </div>
+
+      {/* プログレスバー */}
+      <div
+        style={{
+          width: '100%',
+          height: '8px',
+          backgroundColor: '#e0e0e0',
+          borderRadius: '4px',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${Math.min(totalWeight, 100)}%`,
+            height: '100%',
+            backgroundColor: isValid ? '#4caf50' : totalWeight > 100 ? '#f44336' : '#ff9800',
+            transition: 'width 0.3s ease',
+          }}
+        />
+      </div>
+
+      {/* エラーメッセージ */}
+      {errors.length > 0 && (
+        <div className="ab-mt-2">
+          {errors.map((error, index) => (
+            <p
+              key={index}
+              className="ab-text-body-s"
+              style={{ color: '#f44336', margin: '4px 0' }}
+            >
+              {error}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {isValid && (
+        <p className="ab-text-body-s ab-mt-2" style={{ color: '#4caf50' }}>
+          ウェイト設定は正しく完了しています
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/types/evaluation.ts
+++ b/src/types/evaluation.ts
@@ -1,0 +1,260 @@
+import {
+  Phase,
+  PerformanceRating,
+  CompetencyRating,
+  Grade,
+  Treatment,
+  Half,
+} from '@prisma/client';
+
+// 評価ランクの数値マッピング
+export const performanceRatingValues: Record<PerformanceRating, number> = {
+  SS: 5,
+  S: 4,
+  A: 3,
+  B: 2,
+  C: 1,
+};
+
+// 評価ランクのラベル
+export const performanceRatingLabels: Record<PerformanceRating, string> = {
+  SS: 'SS (5)',
+  S: 'S (4)',
+  A: 'A (3)',
+  B: 'B (2)',
+  C: 'C (1)',
+};
+
+// コンピテンシーレベルのラベル
+export const competencyRatingLabels: Record<CompetencyRating, string> = {
+  LEVEL_2_0: '2.0',
+  LEVEL_2_5: '2.5',
+  LEVEL_3_0_MINUS: '3.0-',
+  LEVEL_3_0: '3.0',
+  LEVEL_3_5: '3.5',
+  LEVEL_4_0: '4.0',
+};
+
+// 等級のラベル
+export const gradeLabels: Record<Grade, string> = {
+  G1: 'G1',
+  G2: 'G2',
+  G3: 'G3',
+  G4: 'G4',
+  G5: 'G5',
+  G6: 'G6',
+  G7: 'G7',
+};
+
+// 処置のラベル
+export const treatmentLabels: Record<Treatment, string> = {
+  raise: '昇給',
+  maintain: '現状維持',
+  reduce: '降給',
+};
+
+// 期のラベル
+export const halfLabels: Record<Half, string> = {
+  first: '上期',
+  second: '下期',
+};
+
+// 目標の自己評価
+export interface GoalSelfEvaluation {
+  id: string;
+  goalId: string;
+  performanceReflection: string | null;
+  performanceRating: PerformanceRating | null;
+  competencyReflection1: string | null;
+  competencyReflection2: string | null;
+  competencyReflection3: string | null;
+  competencyRating: CompetencyRating | null;
+}
+
+// 目標の上長評価
+export interface GoalManagerEvaluation {
+  id: string;
+  goalId: string;
+  performanceComment: string | null;
+  performanceRating: PerformanceRating | null;
+  competencyComment: string | null;
+  competencyRating: CompetencyRating | null;
+}
+
+// 目標
+export interface Goal {
+  id: string;
+  sheetId: string;
+  sortOrder: number;
+  title: string;
+  description: string | null;
+  achievementCriteria: string | null;
+  weight: number;
+  selfEvaluation: GoalSelfEvaluation | null;
+  managerEvaluation: GoalManagerEvaluation | null;
+}
+
+// 総評
+export interface TotalEvaluation {
+  id: string;
+  sheetId: string;
+  averageScore: number | null;
+  performanceComment: string | null;
+  competencyLevel: CompetencyRating | null;
+  competencyLevelReason: string | null;
+  mgrTreatment: Treatment | null;
+  mgrSalaryChange: number | null;
+  mgrTreatmentComment: string | null;
+  mgrGrade: Grade | null;
+  mgrGradeComment: string | null;
+  hrTreatment: Treatment | null;
+  hrSalaryChange: number | null;
+  hrGrade: Grade | null;
+}
+
+// 評価シートの所有者情報
+export interface SheetOwner {
+  id: string;
+  name: string;
+  email: string;
+  employeeNumber: string;
+}
+
+// 評価期間
+export interface EvaluationPeriod {
+  id: string;
+  name: string;
+  year: number;
+  half: Half;
+  startDate: Date;
+  endDate: Date;
+  currentPhase: Phase;
+  isActive: boolean;
+}
+
+// 評価シート（詳細）
+export interface EvaluationSheet {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: Phase;
+  user: SheetOwner;
+  period: EvaluationPeriod;
+  goals: Goal[];
+  totalEvaluation: TotalEvaluation | null;
+}
+
+// 評価シート（一覧用）
+export interface EvaluationSheetSummary {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: Phase;
+  user: SheetOwner;
+  period: {
+    id: string;
+    name: string;
+    year: number;
+    half: Half;
+    currentPhase: Phase;
+  };
+  goalsCount: number;
+  totalWeight: number;
+}
+
+// 目標フォームの入力値
+export interface GoalFormData {
+  title: string;
+  description: string;
+  achievementCriteria: string;
+  weight: number;
+}
+
+// 自己評価フォームの入力値
+export interface SelfEvaluationFormData {
+  performanceReflection: string;
+  performanceRating: PerformanceRating | null;
+  competencyReflection1: string;
+  competencyReflection2: string;
+  competencyReflection3: string;
+  competencyRating: CompetencyRating | null;
+}
+
+// 上長評価フォームの入力値
+export interface ManagerEvaluationFormData {
+  performanceComment: string;
+  performanceRating: PerformanceRating | null;
+  competencyComment: string;
+  competencyRating: CompetencyRating | null;
+}
+
+// Mgr判断フォームの入力値
+export interface MgrJudgmentFormData {
+  competencyLevel: CompetencyRating | null;
+  competencyLevelReason: string;
+  mgrTreatment: Treatment | null;
+  mgrSalaryChange: number | null;
+  mgrTreatmentComment: string;
+  mgrGrade: Grade | null;
+  mgrGradeComment: string;
+}
+
+// HR判断フォームの入力値
+export interface HrJudgmentFormData {
+  hrTreatment: Treatment | null;
+  hrSalaryChange: number | null;
+  hrGrade: Grade | null;
+}
+
+// ウェイトバリデーション結果
+export interface WeightValidation {
+  isValid: boolean;
+  totalWeight: number;
+  errors: string[];
+}
+
+// ウェイトのバリデーション
+export function validateWeights(goals: { weight: number }[]): WeightValidation {
+  const totalWeight = goals.reduce((sum, goal) => sum + goal.weight, 0);
+  const errors: string[] = [];
+
+  if (totalWeight !== 100) {
+    errors.push(`ウェイトの合計は100%である必要があります（現在: ${totalWeight}%）`);
+  }
+
+  goals.forEach((goal, index) => {
+    if (goal.weight > 40) {
+      errors.push(`目標${index + 1}のウェイトは40%を超えています`);
+    }
+    if (goal.weight < 1) {
+      errors.push(`目標${index + 1}のウェイトは1%以上である必要があります`);
+    }
+  });
+
+  return {
+    isValid: errors.length === 0,
+    totalWeight,
+    errors,
+  };
+}
+
+// 平均点の計算
+export function calculateAverageScore(
+  goals: { weight: number; selfEvaluation: { performanceRating: PerformanceRating | null } | null }[]
+): number | null {
+  const goalsWithRating = goals.filter(
+    (g) => g.selfEvaluation?.performanceRating != null
+  );
+
+  if (goalsWithRating.length === 0) return null;
+
+  const totalWeightedScore = goalsWithRating.reduce((sum, goal) => {
+    const rating = goal.selfEvaluation!.performanceRating!;
+    const value = performanceRatingValues[rating];
+    return sum + value * goal.weight;
+  }, 0);
+
+  const totalWeight = goalsWithRating.reduce((sum, goal) => sum + goal.weight, 0);
+
+  return totalWeight > 0 ? Math.round((totalWeightedScore / totalWeight) * 100) / 100 : null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './evaluation';
+export type { Role, Phase, PerformanceRating, CompetencyRating, Grade, Treatment, Half } from '@prisma/client';


### PR DESCRIPTION
## Summary
- 評価シートのコアUI機能を実装
- 目標の追加・編集・削除機能
- 自己評価・上長評価フォーム
- 総評・Mgr判断・HR判断の表示と編集
- ウェイトバリデーション（合計100%、1目標最大40%）
- ワークフローに応じた権限制御

## Changes

### 追加ファイル
- `src/types/evaluation.ts` - 評価関連の型定義
- `src/types/index.ts` - 型エクスポート
- `src/components/sheet/` - 評価シートコンポーネント群
  - `goal-card.tsx` - 目標カード
  - `goal-form.tsx` - 目標フォーム
  - `self-evaluation-form.tsx` - 自己評価フォーム
  - `manager-evaluation-form.tsx` - 上長評価フォーム
  - `total-evaluation.tsx` - 総評セクション
  - `weight-indicator.tsx` - ウェイトインジケーター
  - `evaluation-sheet-client.tsx` - メインクライアントコンポーネント
- `src/app/sheet/[sheetId]/page.tsx` - 評価シートページ

### 変更ファイル
- `src/app/(employee)/dashboard/page.tsx` - シートへのリンク追加

## Implementation Notes
- 現在はモックデータを使用（DB接続後に実データに置き換え予定）
- 権限制御はworkflow.tsのcanEditSheet関数を使用
- 閲覧権限は役割（従業員/管理職/HR）に応じて制御

## Test plan
- [ ] npm run build でビルドが成功することを確認
- [ ] /dashboard から評価シートへのリンクが機能することを確認
- [ ] /sheet/sheet-1 で評価シートが表示されることを確認
- [ ] 目標の追加・編集・削除が動作することを確認
- [ ] 自己評価フォームが開けることを確認
- [ ] ウェイトインジケーターが正しく表示されることを確認

Ref #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)