### PR TITLE
feat: フロントエンドとAPIの結合

### DIFF
--- a/src/app/(employee)/dashboard/page.tsx
+++ b/src/app/(employee)/dashboard/page.tsx
@@ -1,37 +1,7 @@
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { MainLayout } from '@/components/layout/main-layout';
-import { phaseLabels } from '@/lib/workflow';
-import { halfLabels } from '@/types/evaluation';
-import type { Phase, Half } from '@prisma/client';
-
-// モックデータ（データベース接続後に置き換え）
-interface MockSheet {
-  id: string;
-  periodName: string;
-  year: number;
-  half: Half;
-  status: Phase;
-  currentPhase: Phase;
-  goalsCount: number;
-  totalWeight: number;
-}
-
-function getMockSheets(): MockSheet[] {
-  return [
-    {
-      id: 'sheet-1',
-      periodName: '2026年度上期',
-      year: 2026,
-      half: 'first',
-      status: 'goal_setting',
-      currentPhase: 'goal_setting',
-      goalsCount: 4,
-      totalWeight: 100,
-    },
-  ];
-}
+import { SheetsList } from '@/components/dashboard';
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -39,9 +9,6 @@ export default async function DashboardPage() {
   if (!session?.user) {
     redirect('/login');
   }
-
-  const sheets = getMockSheets();
-  const currentSheet = sheets[0];
 
   return (
     <MainLayout>
@@ -51,128 +18,7 @@ export default async function DashboardPage() {
           <p className="ab-text-body-m ab-text-secondary">{session.user.name}さん、こんにちは</p>
         </div>
 
-        <div
-          className="ab-grid ab-gap-4"
-          style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}
-        >
-          {/* 評価シート */}
-          <div
-            className="ab-bg-base ab-rounded-md ab-p-4"
-            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-          >
-            <h2 className="ab-text-heading-m ab-text-default ab-mb-1">評価シート</h2>
-            <p className="ab-text-body-s ab-text-secondary ab-mb-4">現在の評価期間のシート</p>
-            {currentSheet ? (
-              <div className="ab-flex ab-flex-column ab-gap-2">
-                <p className="ab-text-body-m ab-text-default">
-                  {currentSheet.year}年 {halfLabels[currentSheet.half]}
-                </p>
-                <div className="ab-flex ab-items-center ab-gap-2">
-                  <span
-                    className="ab-text-body-s ab-text-on-primary ab-rounded-md"
-                    style={{ backgroundColor: '#1976d2', padding: '2px 8px' }}
-                  >
-                    {phaseLabels[currentSheet.status]}
-                  </span>
-                </div>
-                <Link
-                  href={`/sheet/${currentSheet.id}`}
-                  className="ab-text-body-m"
-                  style={{ color: '#1976d2', textDecoration: 'none' }}
-                >
-                  シートを開く →
-                </Link>
-              </div>
-            ) : (
-              <p className="ab-text-body-m ab-text-secondary">評価シートはまだありません</p>
-            )}
-          </div>
-
-          {/* 目標進捗 */}
-          <div
-            className="ab-bg-base ab-rounded-md ab-p-4"
-            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-          >
-            <h2 className="ab-text-heading-m ab-text-default ab-mb-1">目標進捗</h2>
-            <p className="ab-text-body-s ab-text-secondary ab-mb-4">目標の入力状況</p>
-            {currentSheet ? (
-              <div className="ab-flex ab-flex-column ab-gap-2">
-                <p className="ab-text-body-m ab-text-default">
-                  登録目標数: {currentSheet.goalsCount}/6
-                </p>
-                <p className="ab-text-body-m ab-text-default">
-                  ウェイト合計: {currentSheet.totalWeight}%
-                </p>
-                <div
-                  style={{
-                    width: '100%',
-                    height: '8px',
-                    backgroundColor: '#e0e0e0',
-                    borderRadius: '4px',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: `${Math.min(currentSheet.totalWeight, 100)}%`,
-                      height: '100%',
-                      backgroundColor:
-                        currentSheet.totalWeight === 100 ? '#4caf50' : '#ff9800',
-                    }}
-                  />
-                </div>
-              </div>
-            ) : (
-              <p className="ab-text-body-m ab-text-secondary">目標はまだ設定されていません</p>
-            )}
-          </div>
-
-          {/* 現在のフェーズ */}
-          <div
-            className="ab-bg-base ab-rounded-md ab-p-4"
-            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-          >
-            <h2 className="ab-text-heading-m ab-text-default ab-mb-1">現在のフェーズ</h2>
-            <p className="ab-text-body-s ab-text-secondary ab-mb-4">評価サイクルの状態</p>
-            {currentSheet ? (
-              <div className="ab-flex ab-flex-column ab-gap-2">
-                <p className="ab-text-body-m ab-text-default">
-                  {phaseLabels[currentSheet.currentPhase]}
-                </p>
-                <p className="ab-text-body-s ab-text-secondary">
-                  {currentSheet.currentPhase === 'goal_setting' &&
-                    '目標を入力してください'}
-                  {currentSheet.currentPhase === 'goal_review' &&
-                    '目標の確定を待っています'}
-                  {currentSheet.currentPhase === 'self_evaluation' &&
-                    '自己評価を入力してください'}
-                  {currentSheet.currentPhase === 'self_confirmed' &&
-                    '自己評価の確定を待っています'}
-                  {currentSheet.currentPhase === 'manager_evaluation' &&
-                    '上長評価を待っています'}
-                  {currentSheet.currentPhase === 'manager_confirmed' &&
-                    '上長評価の確定を待っています'}
-                  {currentSheet.currentPhase === 'hr_evaluation' &&
-                    'HR判断を待っています'}
-                  {currentSheet.currentPhase === 'finalized' &&
-                    '評価が確定しました'}
-                </p>
-              </div>
-            ) : (
-              <p className="ab-text-body-m ab-text-secondary">評価期間が設定されていません</p>
-            )}
-          </div>
-        </div>
-
-        {/* 過去の評価シート */}
-        <div
-          className="ab-bg-base ab-rounded-md ab-p-4"
-          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-        >
-          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">過去の評価シート</h2>
-          <p className="ab-text-body-s ab-text-secondary ab-mb-4">過去の評価期間のシート一覧</p>
-          <p className="ab-text-body-m ab-text-secondary">過去のシートはありません</p>
-        </div>
+        <SheetsList />
       </div>
     </MainLayout>
   );

--- a/src/app/sheet/[sheetId]/page.tsx
+++ b/src/app/sheet/[sheetId]/page.tsx
@@ -1,83 +1,7 @@
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { MainLayout } from '@/components/layout/main-layout';
-import { EvaluationSheetClient } from '@/components/sheet/evaluation-sheet-client';
-import { canEditSheet } from '@/lib/workflow';
-import type { EvaluationSheet } from '@/types/evaluation';
-import type { Role } from '@prisma/client';
-
-// モックデータ（データベース接続後に置き換え）
-function getMockSheet(sheetId: string): EvaluationSheet | null {
-  return {
-    id: sheetId,
-    userId: 'user-1',
-    periodId: 'period-1',
-    status: 'goal_setting',
-    user: {
-      id: 'user-1',
-      name: '山田 太郎',
-      email: 'yamada@example.com',
-      employeeNumber: 'EMP001',
-    },
-    period: {
-      id: 'period-1',
-      name: '2026年度上期',
-      year: 2026,
-      half: 'first',
-      startDate: new Date('2026-04-01'),
-      endDate: new Date('2026-09-30'),
-      currentPhase: 'goal_setting',
-      isActive: true,
-    },
-    goals: [
-      {
-        id: 'goal-1',
-        sheetId: sheetId,
-        sortOrder: 1,
-        title: '新規顧客獲得数の増加',
-        description: '新規顧客を前期比120%獲得する',
-        achievementCriteria: '新規顧客獲得数が前期比120%以上',
-        weight: 30,
-        selfEvaluation: null,
-        managerEvaluation: null,
-      },
-      {
-        id: 'goal-2',
-        sheetId: sheetId,
-        sortOrder: 2,
-        title: 'チームの生産性向上',
-        description: 'チーム全体の生産性を15%向上させる',
-        achievementCriteria: '生産性指標が前期比115%以上',
-        weight: 25,
-        selfEvaluation: null,
-        managerEvaluation: null,
-      },
-      {
-        id: 'goal-3',
-        sheetId: sheetId,
-        sortOrder: 3,
-        title: '顧客満足度の維持・向上',
-        description: '顧客満足度調査でAランク以上を維持',
-        achievementCriteria: '顧客満足度調査で90点以上',
-        weight: 25,
-        selfEvaluation: null,
-        managerEvaluation: null,
-      },
-      {
-        id: 'goal-4',
-        sheetId: sheetId,
-        sortOrder: 4,
-        title: '業務プロセスの改善',
-        description: '業務効率化のための改善提案を3件以上実施',
-        achievementCriteria: '改善提案の採用数3件以上',
-        weight: 20,
-        selfEvaluation: null,
-        managerEvaluation: null,
-      },
-    ],
-    totalEvaluation: null,
-  };
-}
+import { EvaluationSheetContainer } from '@/components/sheet';
 
 interface PageProps {
   params: Promise<{ sheetId: string }>;
@@ -91,35 +15,9 @@ export default async function SheetPage({ params }: PageProps) {
     redirect('/login');
   }
 
-  // モックデータを取得（データベース接続後に実際のクエリに置き換え）
-  const sheet = getMockSheet(sheetId);
-
-  if (!sheet) {
-    redirect('/dashboard');
-  }
-
-  const userRoles = (session.user.roles || ['employee']) as Role[];
-  const isOwner = sheet.userId === session.user.id || true; // モック用にtrueに
-  const isManager = userRoles.includes('manager');
-
-  // 編集権限を取得
-  const editPermissions = canEditSheet(
-    sheet.status,
-    sheet.period.currentPhase,
-    userRoles,
-    isOwner,
-    isManager
-  );
-
   return (
     <MainLayout>
-      <EvaluationSheetClient
-        sheet={sheet}
-        editPermissions={editPermissions}
-        userRoles={userRoles}
-        isOwner={isOwner}
-        isManager={isManager}
-      />
+      <EvaluationSheetContainer sheetId={sheetId} />
     </MainLayout>
   );
 }

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { SheetsList } from './sheets-list';

--- a/src/components/dashboard/sheets-list.tsx
+++ b/src/components/dashboard/sheets-list.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { sheetsApi, type SheetSummary, ApiError } from '@/lib/api-client';
+import { phaseLabels } from '@/lib/workflow';
+import { halfLabels } from '@/types/evaluation';
+import type { Phase, Half } from '@prisma/client';
+
+export function SheetsList() {
+  const [sheets, setSheets] = useState<SheetSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSheets() {
+      try {
+        const data = await sheetsApi.list();
+        setSheets(data);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('シートの取得に失敗しました');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchSheets();
+  }, []);
+
+  const currentSheet = sheets.find((s) => s.period.currentPhase !== 'finalized');
+  const pastSheets = sheets.filter((s) => s.period.currentPhase === 'finalized');
+
+  if (isLoading) {
+    return (
+      <div className="ab-flex ab-flex-column ab-gap-4">
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <p className="ab-text-body-m ab-text-secondary">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="ab-flex ab-flex-column ab-gap-4">
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)', borderLeft: '4px solid #f44336' }}
+        >
+          <p className="ab-text-body-m" style={{ color: '#f44336' }}>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="ab-grid ab-gap-4"
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))' }}
+      >
+        {/* 評価シート */}
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">評価シート</h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">現在の評価期間のシート</p>
+          {currentSheet ? (
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              <p className="ab-text-body-m ab-text-default">
+                {currentSheet.period.year}年 {halfLabels[currentSheet.period.half as Half]}
+              </p>
+              <div className="ab-flex ab-items-center ab-gap-2">
+                <span
+                  className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+                  style={{ backgroundColor: '#1976d2', padding: '2px 8px' }}
+                >
+                  {phaseLabels[currentSheet.status as Phase]}
+                </span>
+              </div>
+              <Link
+                href={`/sheet/${currentSheet.id}`}
+                className="ab-text-body-m"
+                style={{ color: '#1976d2', textDecoration: 'none' }}
+              >
+                シートを開く →
+              </Link>
+            </div>
+          ) : (
+            <p className="ab-text-body-m ab-text-secondary">評価シートはまだありません</p>
+          )}
+        </div>
+
+        {/* 目標進捗 */}
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">目標進捗</h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">目標の入力状況</p>
+          {currentSheet ? (
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              <p className="ab-text-body-m ab-text-default">
+                登録目標数: {currentSheet.goalsCount}/6
+              </p>
+              <p className="ab-text-body-m ab-text-default">
+                ウェイト合計: {currentSheet.totalWeight}%
+              </p>
+              <div
+                style={{
+                  width: '100%',
+                  height: '8px',
+                  backgroundColor: '#e0e0e0',
+                  borderRadius: '4px',
+                  overflow: 'hidden',
+                }}
+              >
+                <div
+                  style={{
+                    width: `${Math.min(currentSheet.totalWeight, 100)}%`,
+                    height: '100%',
+                    backgroundColor:
+                      currentSheet.totalWeight === 100 ? '#4caf50' : '#ff9800',
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="ab-text-body-m ab-text-secondary">目標はまだ設定されていません</p>
+          )}
+        </div>
+
+        {/* 現在のフェーズ */}
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">現在のフェーズ</h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">評価サイクルの状態</p>
+          {currentSheet ? (
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              <p className="ab-text-body-m ab-text-default">
+                {phaseLabels[currentSheet.period.currentPhase as Phase]}
+              </p>
+              <p className="ab-text-body-s ab-text-secondary">
+                {currentSheet.period.currentPhase === 'goal_setting' &&
+                  '目標を入力してください'}
+                {currentSheet.period.currentPhase === 'goal_review' &&
+                  '目標の確定を待っています'}
+                {currentSheet.period.currentPhase === 'self_evaluation' &&
+                  '自己評価を入力してください'}
+                {currentSheet.period.currentPhase === 'self_confirmed' &&
+                  '自己評価の確定を待っています'}
+                {currentSheet.period.currentPhase === 'manager_evaluation' &&
+                  '上長評価を待っています'}
+                {currentSheet.period.currentPhase === 'manager_confirmed' &&
+                  '上長評価の確定を待っています'}
+                {currentSheet.period.currentPhase === 'hr_evaluation' &&
+                  'HR判断を待っています'}
+                {currentSheet.period.currentPhase === 'finalized' &&
+                  '評価が確定しました'}
+              </p>
+            </div>
+          ) : (
+            <p className="ab-text-body-m ab-text-secondary">評価期間が設定されていません</p>
+          )}
+        </div>
+      </div>
+
+      {/* 過去の評価シート */}
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <h2 className="ab-text-heading-m ab-text-default ab-mb-1">過去の評価シート</h2>
+        <p className="ab-text-body-s ab-text-secondary ab-mb-4">過去の評価期間のシート一覧</p>
+        {pastSheets.length > 0 ? (
+          <div className="ab-flex ab-flex-column ab-gap-2">
+            {pastSheets.map((sheet) => (
+              <Link
+                key={sheet.id}
+                href={`/sheet/${sheet.id}`}
+                className="ab-flex ab-items-center ab-justify-between ab-p-2 ab-rounded-md"
+                style={{
+                  textDecoration: 'none',
+                  backgroundColor: '#f5f5f5',
+                }}
+              >
+                <span className="ab-text-body-m ab-text-default">
+                  {sheet.period.year}年 {halfLabels[sheet.period.half as Half]}
+                </span>
+                <span className="ab-text-body-s ab-text-secondary">
+                  {phaseLabels[sheet.status as Phase]}
+                </span>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="ab-text-body-m ab-text-secondary">過去のシートはありません</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/sheet/evaluation-sheet-container.tsx
+++ b/src/components/sheet/evaluation-sheet-container.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSheet } from '@/hooks/use-sheet';
+import { EvaluationSheetView } from './evaluation-sheet-view';
+
+interface EvaluationSheetContainerProps {
+  sheetId: string;
+}
+
+export function EvaluationSheetContainer({ sheetId }: EvaluationSheetContainerProps) {
+  const {
+    sheet,
+    isLoading,
+    error,
+    fetchSheet,
+    addGoal,
+    updateGoal,
+    deleteGoal,
+    updateSelfEvaluation,
+    updateManagerEvaluation,
+    updateTotalEvaluation,
+  } = useSheet();
+
+  useEffect(() => {
+    fetchSheet(sheetId);
+  }, [sheetId, fetchSheet]);
+
+  if (isLoading && !sheet) {
+    return (
+      <div className="ab-flex ab-items-center ab-justify-center" style={{ minHeight: '400px' }}>
+        <p className="ab-text-body-m ab-text-secondary">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error && !sheet) {
+    return (
+      <div className="ab-flex ab-flex-column ab-items-center ab-justify-center ab-gap-4" style={{ minHeight: '400px' }}>
+        <p className="ab-text-body-m" style={{ color: '#f44336' }}>{error}</p>
+        <button
+          onClick={() => fetchSheet(sheetId)}
+          className="ab-text-body-m"
+          style={{
+            padding: '8px 16px',
+            border: '1px solid #1976d2',
+            borderRadius: '4px',
+            color: '#1976d2',
+            backgroundColor: 'white',
+            cursor: 'pointer',
+          }}
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  if (!sheet) {
+    return (
+      <div className="ab-flex ab-items-center ab-justify-center" style={{ minHeight: '400px' }}>
+        <p className="ab-text-body-m ab-text-secondary">シートが見つかりません</p>
+      </div>
+    );
+  }
+
+  return (
+    <EvaluationSheetView
+      sheet={sheet}
+      isLoading={isLoading}
+      error={error}
+      onAddGoal={addGoal}
+      onUpdateGoal={updateGoal}
+      onDeleteGoal={deleteGoal}
+      onUpdateSelfEvaluation={updateSelfEvaluation}
+      onUpdateManagerEvaluation={updateManagerEvaluation}
+      onUpdateTotalEvaluation={updateTotalEvaluation}
+    />
+  );
+}

--- a/src/components/sheet/evaluation-sheet-view.tsx
+++ b/src/components/sheet/evaluation-sheet-view.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@giftee/abukuma-react';
+import {
+  GoalCard,
+  GoalForm,
+  GoalFormOverlay,
+  SelfEvaluationForm,
+  ManagerEvaluationForm,
+  TotalEvaluationSection,
+  MgrJudgmentForm,
+  HrJudgmentForm,
+  WeightIndicator,
+} from '@/components/sheet';
+import type {
+  GoalFormData,
+  SelfEvaluationFormData,
+  ManagerEvaluationFormData,
+  MgrJudgmentFormData,
+  HrJudgmentFormData,
+} from '@/types/evaluation';
+import { validateWeights, calculateAverageScore, halfLabels } from '@/types/evaluation';
+import { phaseLabels } from '@/lib/workflow';
+import type {
+  SheetDetail,
+  Goal,
+  GoalCreateData,
+  GoalUpdateData,
+  SelfEvaluationData,
+  ManagerEvaluationData,
+  TotalEvaluationData,
+} from '@/lib/api-client';
+import type { Phase, Half, Role, PerformanceRating, CompetencyRating } from '@prisma/client';
+
+interface EvaluationSheetViewProps {
+  sheet: SheetDetail;
+  isLoading: boolean;
+  error: string | null;
+  onAddGoal: (data: GoalCreateData) => Promise<Goal | null>;
+  onUpdateGoal: (goalId: string, data: GoalUpdateData) => Promise<Goal | null>;
+  onDeleteGoal: (goalId: string) => Promise<boolean>;
+  onUpdateSelfEvaluation: (goalId: string, data: SelfEvaluationData) => Promise<boolean>;
+  onUpdateManagerEvaluation: (goalId: string, data: ManagerEvaluationData) => Promise<boolean>;
+  onUpdateTotalEvaluation: (data: TotalEvaluationData) => Promise<boolean>;
+}
+
+type ModalState =
+  | { type: 'none' }
+  | { type: 'goalForm'; goal: Goal | null }
+  | { type: 'selfEvaluation'; goal: Goal }
+  | { type: 'managerEvaluation'; goal: Goal }
+  | { type: 'mgrJudgment' }
+  | { type: 'hrJudgment' }
+  | { type: 'deleteConfirm'; goalId: string };
+
+// Convert API types to component types
+function convertGoalForCard(goal: Goal) {
+  return {
+    ...goal,
+    selfEvaluation: goal.selfEvaluation
+      ? {
+          ...goal.selfEvaluation,
+          performanceRating: goal.selfEvaluation.performanceRating as PerformanceRating | null,
+          competencyRating: goal.selfEvaluation.competencyRating as CompetencyRating | null,
+        }
+      : null,
+    managerEvaluation: goal.managerEvaluation
+      ? {
+          ...goal.managerEvaluation,
+          performanceRating: goal.managerEvaluation.performanceRating as PerformanceRating | null,
+          competencyRating: goal.managerEvaluation.competencyRating as CompetencyRating | null,
+        }
+      : null,
+  };
+}
+
+export function EvaluationSheetView({
+  sheet,
+  isLoading,
+  error,
+  onAddGoal,
+  onUpdateGoal,
+  onDeleteGoal,
+  onUpdateSelfEvaluation,
+  onUpdateManagerEvaluation,
+  onUpdateTotalEvaluation,
+}: EvaluationSheetViewProps) {
+  const [modalState, setModalState] = useState<ModalState>({ type: 'none' });
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const editPermissions = sheet.editPermissions;
+  const userRoles: Role[] = sheet.isOwner ? ['employee'] : sheet.isManager ? ['manager'] : ['hr'];
+
+  // Calculate weight validation
+  const weightValidation = validateWeights(sheet.goals);
+
+  // Calculate average score
+  const goalsForScore = sheet.goals.map((g) => ({
+    weight: g.weight,
+    selfEvaluation: g.selfEvaluation
+      ? { performanceRating: g.selfEvaluation.performanceRating as PerformanceRating | null }
+      : null,
+  }));
+  const averageScore = calculateAverageScore(goalsForScore);
+
+  // Permission checks for visibility
+  const showManagerEvaluation = !sheet.isOwner || sheet.isManager;
+  const showMgrJudgment = !sheet.isOwner;
+  const showHrJudgment = !sheet.isOwner;
+
+  // Goal handlers
+  const handleGoalSubmit = async (data: GoalFormData) => {
+    setActionLoading(true);
+    try {
+      const editingGoal = modalState.type === 'goalForm' ? modalState.goal : null;
+
+      if (editingGoal) {
+        await onUpdateGoal(editingGoal.id, {
+          title: data.title,
+          description: data.description || undefined,
+          achievementCriteria: data.achievementCriteria || undefined,
+          weight: data.weight,
+        });
+      } else {
+        await onAddGoal({
+          title: data.title,
+          description: data.description || undefined,
+          achievementCriteria: data.achievementCriteria || undefined,
+          weight: data.weight,
+        });
+      }
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleGoalDelete = async (goalId: string) => {
+    setActionLoading(true);
+    try {
+      await onDeleteGoal(goalId);
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleSelfEvaluationSubmit = async (goalId: string, data: SelfEvaluationFormData) => {
+    setActionLoading(true);
+    try {
+      await onUpdateSelfEvaluation(goalId, {
+        performanceReflection: data.performanceReflection || undefined,
+        performanceRating: data.performanceRating || undefined,
+        competencyReflection1: data.competencyReflection1 || undefined,
+        competencyReflection2: data.competencyReflection2 || undefined,
+        competencyReflection3: data.competencyReflection3 || undefined,
+        competencyRating: data.competencyRating || undefined,
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleManagerEvaluationSubmit = async (
+    goalId: string,
+    data: ManagerEvaluationFormData
+  ) => {
+    setActionLoading(true);
+    try {
+      await onUpdateManagerEvaluation(goalId, {
+        performanceComment: data.performanceComment || undefined,
+        performanceRating: data.performanceRating || undefined,
+        competencyComment: data.competencyComment || undefined,
+        competencyRating: data.competencyRating || undefined,
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleMgrJudgmentSubmit = async (data: MgrJudgmentFormData) => {
+    setActionLoading(true);
+    try {
+      await onUpdateTotalEvaluation({
+        competencyLevel: data.competencyLevel || undefined,
+        competencyLevelReason: data.competencyLevelReason || undefined,
+        mgrTreatment: data.mgrTreatment || undefined,
+        mgrSalaryChange: data.mgrSalaryChange ?? undefined,
+        mgrTreatmentComment: data.mgrTreatmentComment || undefined,
+        mgrGrade: data.mgrGrade || undefined,
+        mgrGradeComment: data.mgrGradeComment || undefined,
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleHrJudgmentSubmit = async (data: HrJudgmentFormData) => {
+    setActionLoading(true);
+    try {
+      await onUpdateTotalEvaluation({
+        hrTreatment: data.hrTreatment || undefined,
+        hrSalaryChange: data.hrSalaryChange ?? undefined,
+        hrGrade: data.hrGrade || undefined,
+      });
+      setModalState({ type: 'none' });
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const totalEvaluationForDisplay = sheet.totalEvaluation
+    ? {
+        ...sheet.totalEvaluation,
+        averageScore: sheet.totalEvaluation.averageScore,
+        competencyLevel: sheet.totalEvaluation.competencyLevel as CompetencyRating | null,
+        mgrTreatment: sheet.totalEvaluation.mgrTreatment as 'raise' | 'maintain' | 'reduce' | null,
+        mgrGrade: sheet.totalEvaluation.mgrGrade as 'G1' | 'G2' | 'G3' | 'G4' | 'G5' | 'G6' | 'G7' | null,
+        hrTreatment: sheet.totalEvaluation.hrTreatment as 'raise' | 'maintain' | 'reduce' | null,
+        hrGrade: sheet.totalEvaluation.hrGrade as 'G1' | 'G2' | 'G3' | 'G4' | 'G5' | 'G6' | 'G7' | null,
+      }
+    : null;
+
+  return (
+    <div className="ab-flex ab-flex-column ab-gap-6">
+      {/* Error display */}
+      {error && (
+        <div
+          className="ab-rounded-md ab-p-4"
+          style={{ backgroundColor: '#ffebee', border: '1px solid #f44336' }}
+        >
+          <p className="ab-text-body-m" style={{ color: '#f44336' }}>{error}</p>
+        </div>
+      )}
+
+      {/* Header */}
+      <div>
+        <div className="ab-flex ab-items-center ab-gap-4 ab-mb-2">
+          <h1 className="ab-text-heading-l ab-text-default">評価シート</h1>
+          <span
+            className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+            style={{ backgroundColor: '#1976d2', padding: '4px 12px' }}
+          >
+            {phaseLabels[sheet.status as Phase]}
+          </span>
+          {(isLoading || actionLoading) && (
+            <span className="ab-text-body-s ab-text-secondary">保存中...</span>
+          )}
+        </div>
+        <p className="ab-text-body-m ab-text-secondary">
+          {sheet.user.name} / {sheet.period.year}年 {halfLabels[sheet.period.half as Half]}（
+          {sheet.period.name}）
+        </p>
+      </div>
+
+      {/* Weight Indicator */}
+      {sheet.goals.length > 0 && <WeightIndicator validation={weightValidation} />}
+
+      {/* Goals List */}
+      <div>
+        <div className="ab-flex ab-items-center ab-justify-between ab-mb-4">
+          <h2 className="ab-text-heading-m ab-text-default">
+            目標一覧（{sheet.goals.length}/6）
+          </h2>
+          {editPermissions.canEditGoals && sheet.goals.length < 6 && (
+            <Button
+              variant="default"
+              onClick={() => setModalState({ type: 'goalForm', goal: null })}
+              disabled={isLoading || actionLoading}
+            >
+              目標を追加
+            </Button>
+          )}
+        </div>
+
+        {sheet.goals.length === 0 ? (
+          <div
+            className="ab-bg-base ab-rounded-md ab-p-8 ab-text-center"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+          >
+            <p className="ab-text-body-m ab-text-secondary ab-mb-4">
+              まだ目標が登録されていません
+            </p>
+            {editPermissions.canEditGoals && (
+              <Button
+                variant="default"
+                onClick={() => setModalState({ type: 'goalForm', goal: null })}
+                disabled={isLoading || actionLoading}
+              >
+                最初の目標を追加
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="ab-flex ab-flex-column ab-gap-4">
+            {sheet.goals
+              .sort((a, b) => a.sortOrder - b.sortOrder)
+              .map((goal, index) => (
+                <GoalCard
+                  key={goal.id}
+                  goal={convertGoalForCard(goal)}
+                  index={index}
+                  canEditGoal={editPermissions.canEditGoals}
+                  canEditSelfEvaluation={editPermissions.canEditSelfEvaluation}
+                  canEditManagerEvaluation={editPermissions.canEditManagerEvaluation}
+                  showManagerEvaluation={showManagerEvaluation}
+                  onEdit={(g) => setModalState({ type: 'goalForm', goal: g as Goal })}
+                  onDelete={(id) => setModalState({ type: 'deleteConfirm', goalId: id })}
+                  onEditSelfEvaluation={(g) =>
+                    setModalState({ type: 'selfEvaluation', goal: g as Goal })
+                  }
+                  onEditManagerEvaluation={(g) =>
+                    setModalState({ type: 'managerEvaluation', goal: g as Goal })
+                  }
+                />
+              ))}
+          </div>
+        )}
+      </div>
+
+      {/* Total Evaluation Section */}
+      <TotalEvaluationSection
+        totalEvaluation={totalEvaluationForDisplay}
+        averageScore={averageScore}
+        canEditMgrJudgment={editPermissions.canEditManagerEvaluation}
+        canEditHrJudgment={editPermissions.canEditHrEvaluation}
+        showMgrJudgment={showMgrJudgment}
+        showHrJudgment={showHrJudgment}
+        onEditMgrJudgment={() => setModalState({ type: 'mgrJudgment' })}
+        onEditHrJudgment={() => setModalState({ type: 'hrJudgment' })}
+      />
+
+      {/* Modals */}
+      {modalState.type !== 'none' && (
+        <GoalFormOverlay onClose={() => setModalState({ type: 'none' })} />
+      )}
+
+      {modalState.type === 'goalForm' && (
+        <GoalForm
+          goal={modalState.goal ? convertGoalForCard(modalState.goal) : null}
+          onSubmit={handleGoalSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={actionLoading}
+        />
+      )}
+
+      {modalState.type === 'selfEvaluation' && (
+        <SelfEvaluationForm
+          goal={convertGoalForCard(modalState.goal)}
+          onSubmit={handleSelfEvaluationSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={actionLoading}
+        />
+      )}
+
+      {modalState.type === 'managerEvaluation' && (
+        <ManagerEvaluationForm
+          goal={convertGoalForCard(modalState.goal)}
+          onSubmit={handleManagerEvaluationSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={actionLoading}
+        />
+      )}
+
+      {modalState.type === 'mgrJudgment' && (
+        <MgrJudgmentForm
+          totalEvaluation={totalEvaluationForDisplay}
+          onSubmit={handleMgrJudgmentSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={actionLoading}
+        />
+      )}
+
+      {modalState.type === 'hrJudgment' && (
+        <HrJudgmentForm
+          totalEvaluation={totalEvaluationForDisplay}
+          onSubmit={handleHrJudgmentSubmit}
+          onCancel={() => setModalState({ type: 'none' })}
+          isLoading={actionLoading}
+        />
+      )}
+
+      {modalState.type === 'deleteConfirm' && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-6"
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '90%',
+            maxWidth: '400px',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+            zIndex: 1000,
+          }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-2">目標の削除</h2>
+          <p className="ab-text-body-m ab-text-secondary ab-mb-4">
+            この目標を削除してもよろしいですか？この操作は取り消せません。
+          </p>
+          <div className="ab-flex ab-gap-2 ab-justify-end">
+            <Button
+              variant="outlined"
+              onClick={() => setModalState({ type: 'none' })}
+              disabled={actionLoading}
+            >
+              キャンセル
+            </Button>
+            <Button
+              variant="negative"
+              onClick={() => handleGoalDelete(modalState.goalId)}
+              disabled={actionLoading}
+            >
+              {actionLoading ? '削除中...' : '削除'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sheet/index.ts
+++ b/src/components/sheet/index.ts
@@ -5,3 +5,5 @@ export { ManagerEvaluationForm } from './manager-evaluation-form';
 export { TotalEvaluationSection, MgrJudgmentForm, HrJudgmentForm } from './total-evaluation';
 export { WeightIndicator } from './weight-indicator';
 export { EvaluationSheetClient } from './evaluation-sheet-client';
+export { EvaluationSheetContainer } from './evaluation-sheet-container';
+export { EvaluationSheetView } from './evaluation-sheet-view';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSheet } from './use-sheet';

--- a/src/hooks/use-sheet.ts
+++ b/src/hooks/use-sheet.ts
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  sheetsApi,
+  goalsApi,
+  totalEvaluationApi,
+  ApiError,
+  type SheetDetail,
+  type Goal,
+  type GoalCreateData,
+  type GoalUpdateData,
+  type SelfEvaluationData,
+  type ManagerEvaluationData,
+  type TotalEvaluationData,
+} from '@/lib/api-client';
+
+interface UseSheetReturn {
+  sheet: SheetDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchSheet: (sheetId: string) => Promise<void>;
+  addGoal: (data: GoalCreateData) => Promise<Goal | null>;
+  updateGoal: (goalId: string, data: GoalUpdateData) => Promise<Goal | null>;
+  deleteGoal: (goalId: string) => Promise<boolean>;
+  updateSelfEvaluation: (goalId: string, data: SelfEvaluationData) => Promise<boolean>;
+  updateManagerEvaluation: (goalId: string, data: ManagerEvaluationData) => Promise<boolean>;
+  updateTotalEvaluation: (data: TotalEvaluationData) => Promise<boolean>;
+  updateSheetStatus: (status: string) => Promise<boolean>;
+  refreshSheet: () => Promise<void>;
+}
+
+export function useSheet(): UseSheetReturn {
+  const [sheet, setSheet] = useState<SheetDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentSheetId, setCurrentSheetId] = useState<string | null>(null);
+
+  const fetchSheet = useCallback(async (sheetId: string) => {
+    setIsLoading(true);
+    setError(null);
+    setCurrentSheetId(sheetId);
+
+    try {
+      const data = await sheetsApi.get(sheetId);
+      setSheet(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('シートの取得に失敗しました');
+      }
+      setSheet(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refreshSheet = useCallback(async () => {
+    if (currentSheetId) {
+      await fetchSheet(currentSheetId);
+    }
+  }, [currentSheetId, fetchSheet]);
+
+  const addGoal = useCallback(
+    async (data: GoalCreateData): Promise<Goal | null> => {
+      if (!sheet) return null;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const newGoal = await goalsApi.create(sheet.id, data);
+        await refreshSheet();
+        return newGoal;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('目標の追加に失敗しました');
+        }
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [sheet, refreshSheet]
+  );
+
+  const updateGoal = useCallback(
+    async (goalId: string, data: GoalUpdateData): Promise<Goal | null> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const updatedGoal = await goalsApi.update(goalId, data);
+        await refreshSheet();
+        return updatedGoal;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('目標の更新に失敗しました');
+        }
+        return null;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [refreshSheet]
+  );
+
+  const deleteGoal = useCallback(
+    async (goalId: string): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        await goalsApi.delete(goalId);
+        await refreshSheet();
+        return true;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('目標の削除に失敗しました');
+        }
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [refreshSheet]
+  );
+
+  const updateSelfEvaluation = useCallback(
+    async (goalId: string, data: SelfEvaluationData): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        await goalsApi.updateSelfEvaluation(goalId, data);
+        await refreshSheet();
+        return true;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('自己評価の保存に失敗しました');
+        }
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [refreshSheet]
+  );
+
+  const updateManagerEvaluation = useCallback(
+    async (goalId: string, data: ManagerEvaluationData): Promise<boolean> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        await goalsApi.updateManagerEvaluation(goalId, data);
+        await refreshSheet();
+        return true;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('上長評価の保存に失敗しました');
+        }
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [refreshSheet]
+  );
+
+  const updateTotalEvaluation = useCallback(
+    async (data: TotalEvaluationData): Promise<boolean> => {
+      if (!sheet) return false;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        await totalEvaluationApi.update(sheet.id, data);
+        await refreshSheet();
+        return true;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('総評の保存に失敗しました');
+        }
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [sheet, refreshSheet]
+  );
+
+  const updateSheetStatus = useCallback(
+    async (status: string): Promise<boolean> => {
+      if (!sheet) return false;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        await sheetsApi.updateStatus(sheet.id, status);
+        await refreshSheet();
+        return true;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('ステータスの更新に失敗しました');
+        }
+        return false;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [sheet, refreshSheet]
+  );
+
+  return {
+    sheet,
+    isLoading,
+    error,
+    fetchSheet,
+    addGoal,
+    updateGoal,
+    deleteGoal,
+    updateSelfEvaluation,
+    updateManagerEvaluation,
+    updateTotalEvaluation,
+    updateSheetStatus,
+    refreshSheet,
+  };
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,247 @@
+// API client utility for making fetch requests
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+interface FetchOptions extends RequestInit {
+  params?: Record<string, string>;
+}
+
+async function fetchApi<T>(url: string, options: FetchOptions = {}): Promise<T> {
+  const { params, ...fetchOptions } = options;
+
+  // Add query parameters if provided
+  let fullUrl = url;
+  if (params) {
+    const searchParams = new URLSearchParams(params);
+    fullUrl = `${url}?${searchParams.toString()}`;
+  }
+
+  const response = await fetch(fullUrl, {
+    ...fetchOptions,
+    headers: {
+      'Content-Type': 'application/json',
+      ...fetchOptions.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new ApiError(response.status, errorData.error || 'リクエストに失敗しました');
+  }
+
+  return response.json();
+}
+
+// Sheet API
+export const sheetsApi = {
+  list: (periodId?: string) =>
+    fetchApi<SheetSummary[]>('/api/sheets', {
+      params: periodId ? { periodId } : undefined,
+    }),
+
+  get: (sheetId: string) => fetchApi<SheetDetail>(`/api/sheets/${sheetId}`),
+
+  updateStatus: (sheetId: string, status: string) =>
+    fetchApi(`/api/sheets/${sheetId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status }),
+    }),
+};
+
+// Goals API
+export const goalsApi = {
+  create: (sheetId: string, data: GoalCreateData) =>
+    fetchApi<Goal>(`/api/sheets/${sheetId}/goals`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  update: (goalId: string, data: GoalUpdateData) =>
+    fetchApi<Goal>(`/api/goals/${goalId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (goalId: string) =>
+    fetchApi<{ success: boolean }>(`/api/goals/${goalId}`, {
+      method: 'DELETE',
+    }),
+
+  updateSelfEvaluation: (goalId: string, data: SelfEvaluationData) =>
+    fetchApi(`/api/goals/${goalId}/self-evaluation`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  updateManagerEvaluation: (goalId: string, data: ManagerEvaluationData) =>
+    fetchApi(`/api/goals/${goalId}/manager-evaluation`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+};
+
+// Total Evaluation API
+export const totalEvaluationApi = {
+  update: (sheetId: string, data: TotalEvaluationData) =>
+    fetchApi(`/api/sheets/${sheetId}/total-evaluation`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+};
+
+// Types for API responses and requests
+export interface SheetSummary {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    employeeNumber: string;
+  };
+  period: {
+    id: string;
+    name: string;
+    year: number;
+    half: string;
+    currentPhase: string;
+  };
+  goalsCount: number;
+  totalWeight: number;
+}
+
+export interface SheetDetail {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    employeeNumber: string;
+  };
+  period: {
+    id: string;
+    name: string;
+    year: number;
+    half: string;
+    startDate: string;
+    endDate: string;
+    currentPhase: string;
+    isActive: boolean;
+  };
+  goals: Goal[];
+  totalEvaluation: TotalEvaluation | null;
+  editPermissions: {
+    canEditGoals: boolean;
+    canEditSelfEvaluation: boolean;
+    canEditManagerEvaluation: boolean;
+    canEditHrEvaluation: boolean;
+  };
+  isOwner: boolean;
+  isManager: boolean;
+}
+
+export interface Goal {
+  id: string;
+  sheetId: string;
+  sortOrder: number;
+  title: string;
+  description: string | null;
+  achievementCriteria: string | null;
+  weight: number;
+  selfEvaluation: SelfEvaluation | null;
+  managerEvaluation: ManagerEvaluation | null;
+}
+
+export interface SelfEvaluation {
+  id: string;
+  goalId: string;
+  performanceReflection: string | null;
+  performanceRating: string | null;
+  competencyReflection1: string | null;
+  competencyReflection2: string | null;
+  competencyReflection3: string | null;
+  competencyRating: string | null;
+}
+
+export interface ManagerEvaluation {
+  id: string;
+  goalId: string;
+  performanceComment: string | null;
+  performanceRating: string | null;
+  competencyComment: string | null;
+  competencyRating: string | null;
+}
+
+export interface TotalEvaluation {
+  id: string;
+  sheetId: string;
+  averageScore: number | null;
+  performanceComment: string | null;
+  competencyLevel: string | null;
+  competencyLevelReason: string | null;
+  mgrTreatment: string | null;
+  mgrSalaryChange: number | null;
+  mgrTreatmentComment: string | null;
+  mgrGrade: string | null;
+  mgrGradeComment: string | null;
+  hrTreatment: string | null;
+  hrSalaryChange: number | null;
+  hrGrade: string | null;
+}
+
+export interface GoalCreateData {
+  title: string;
+  description?: string;
+  achievementCriteria?: string;
+  weight: number;
+}
+
+export interface GoalUpdateData {
+  title?: string;
+  description?: string;
+  achievementCriteria?: string;
+  weight?: number;
+  sortOrder?: number;
+}
+
+export interface SelfEvaluationData {
+  performanceReflection?: string;
+  performanceRating?: string | null;
+  competencyReflection1?: string;
+  competencyReflection2?: string;
+  competencyReflection3?: string;
+  competencyRating?: string | null;
+}
+
+export interface ManagerEvaluationData {
+  performanceComment?: string;
+  performanceRating?: string | null;
+  competencyComment?: string;
+  competencyRating?: string | null;
+}
+
+export interface TotalEvaluationData {
+  competencyLevel?: string | null;
+  competencyLevelReason?: string;
+  mgrTreatment?: string | null;
+  mgrSalaryChange?: number | null;
+  mgrTreatmentComment?: string;
+  mgrGrade?: string | null;
+  mgrGradeComment?: string;
+  hrTreatment?: string | null;
+  hrSalaryChange?: number | null;
+  hrGrade?: string | null;
+}


### PR DESCRIPTION
## Summary
- APIクライアントユーティリティを新規作成 (`src/lib/api-client.ts`)
- 評価シート操作用カスタムフック (`src/hooks/use-sheet.ts`) を実装
- 評価シートをコンテナ/ビューパターンで分離し、API連携に対応
- ダッシュボードページをAPI経由でデータ取得するように変更
- 既存のモックデータを削除

## Test plan
- [ ] ダッシュボードでシート一覧が正しく表示される
- [ ] 評価シートページでデータが正しく読み込まれる
- [ ] 目標の追加・編集・削除が動作する
- [ ] 自己評価・上長評価の更新が動作する
- [ ] ローディング・エラー状態が適切に表示される

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)