### PR TITLE
feat: 管理職向け・HR向け画面の実装

### DIFF
--- a/src/app/(hr)/employees/page.tsx
+++ b/src/app/(hr)/employees/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { MainLayout } from '@/components/layout/main-layout';
 import { hasRole } from '@/lib/permissions';
+import { EmployeesList } from '@/components/hr';
 
 export default async function EmployeesPage() {
   const session = await auth();
@@ -22,14 +23,7 @@ export default async function EmployeesPage() {
           <p className="ab-text-body-m ab-text-secondary">全従業員の評価シート一覧</p>
         </div>
 
-        <div
-          className="ab-bg-base ab-rounded-md ab-p-4"
-          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-        >
-          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">従業員検索</h2>
-          <p className="ab-text-body-s ab-text-secondary ab-mb-4">名前、部署、ステータスで検索</p>
-          <p className="ab-text-body-m ab-text-secondary">従業員データがまだ登録されていません</p>
-        </div>
+        <EmployeesList />
       </div>
     </MainLayout>
   );

--- a/src/app/(hr)/periods/page.tsx
+++ b/src/app/(hr)/periods/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { MainLayout } from '@/components/layout/main-layout';
 import { hasRole } from '@/lib/permissions';
+import { PeriodsList } from '@/components/hr';
 
 export default async function PeriodsPage() {
   const session = await auth();
@@ -22,14 +23,7 @@ export default async function PeriodsPage() {
           <p className="ab-text-body-m ab-text-secondary">評価期間の作成とフェーズ管理</p>
         </div>
 
-        <div
-          className="ab-bg-base ab-rounded-md ab-p-4"
-          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-        >
-          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">評価期間一覧</h2>
-          <p className="ab-text-body-s ab-text-secondary ab-mb-4">作成済みの評価期間</p>
-          <p className="ab-text-body-m ab-text-secondary">評価期間がまだ作成されていません</p>
-        </div>
+        <PeriodsList />
       </div>
     </MainLayout>
   );

--- a/src/app/(manager)/team/page.tsx
+++ b/src/app/(manager)/team/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { MainLayout } from '@/components/layout/main-layout';
 import { hasAnyRole } from '@/lib/permissions';
+import { TeamList } from '@/components/team';
 
 export default async function TeamPage() {
   const session = await auth();
@@ -22,16 +23,7 @@ export default async function TeamPage() {
           <p className="ab-text-body-m ab-text-secondary">管理対象の従業員一覧</p>
         </div>
 
-        <div
-          className="ab-bg-base ab-rounded-md ab-p-4"
-          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
-        >
-          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">部下の評価シート</h2>
-          <p className="ab-text-body-s ab-text-secondary ab-mb-4">管理対象従業員の評価状況</p>
-          <p className="ab-text-body-m ab-text-secondary">
-            管理対象の従業員はまだ登録されていません
-          </p>
-        </div>
+        <TeamList />
       </div>
     </MainLayout>
   );

--- a/src/app/api/employees/route.ts
+++ b/src/app/api/employees/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { hasRole } from '@/lib/permissions';
+import type { Role, Phase } from '@prisma/client';
+
+// GET /api/employees - 全従業員一覧取得（HR専用）
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const periodId = searchParams.get('periodId');
+    const search = searchParams.get('search');
+    const departmentId = searchParams.get('departmentId');
+    const status = searchParams.get('status');
+
+    // アクティブな期間を取得（periodIdが指定されていない場合）
+    let targetPeriodId = periodId;
+    if (!targetPeriodId) {
+      const activePeriod = await prisma.evaluationPeriod.findFirst({
+        where: { isActive: true },
+        select: { id: true },
+      });
+      targetPeriodId = activePeriod?.id || null;
+    }
+
+    // 全従業員のシートを取得
+    const sheets = await prisma.evaluationSheet.findMany({
+      where: {
+        ...(targetPeriodId ? { periodId: targetPeriodId } : {}),
+        ...(status ? { status: status as Phase } : {}),
+        user: {
+          isActive: true,
+          ...(search
+            ? {
+                OR: [
+                  { name: { contains: search, mode: 'insensitive' } },
+                  { email: { contains: search, mode: 'insensitive' } },
+                  { employeeNumber: { contains: search, mode: 'insensitive' } },
+                ],
+              }
+            : {}),
+        },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            employeeNumber: true,
+          },
+        },
+        period: {
+          select: {
+            id: true,
+            name: true,
+            year: true,
+            half: true,
+            currentPhase: true,
+          },
+        },
+        goals: {
+          select: {
+            id: true,
+            weight: true,
+          },
+        },
+      },
+      orderBy: [{ user: { name: 'asc' } }],
+    });
+
+    // 期間アサインメント情報を取得
+    const sheetIds = sheets.map((s) => s.id);
+    const assignments = await prisma.periodAssignment.findMany({
+      where: {
+        periodId: targetPeriodId || undefined,
+        userId: { in: sheets.map((s) => s.userId) },
+        ...(departmentId ? { departmentId } : {}),
+      },
+      include: {
+        department: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        manager: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    const assignmentMap = new Map(
+      assignments.map((a) => [`${a.userId}-${a.periodId}`, a])
+    );
+
+    // 部署フィルタがある場合、該当するユーザーのみに絞る
+    const filteredSheets = departmentId
+      ? sheets.filter((sheet) => {
+          const assignment = assignmentMap.get(`${sheet.userId}-${sheet.periodId}`);
+          return assignment?.departmentId === departmentId;
+        })
+      : sheets;
+
+    // シートに詳細情報を追加
+    const sheetsWithDetails = filteredSheets.map((sheet) => {
+      const assignment = assignmentMap.get(`${sheet.userId}-${sheet.periodId}`);
+      return {
+        ...sheet,
+        goalsCount: sheet.goals.length,
+        totalWeight: sheet.goals.reduce((sum, g) => sum + g.weight, 0),
+        goals: undefined,
+        department: assignment?.department || null,
+        manager: assignment?.manager || null,
+        currentGrade: assignment?.currentGrade || null,
+      };
+    });
+
+    return NextResponse.json(sheetsWithDetails);
+  } catch (error) {
+    console.error('Error fetching employees:', error);
+    return NextResponse.json({ error: '従業員一覧の取得に失敗しました' }, { status: 500 });
+  }
+}

--- a/src/app/api/periods/[periodId]/route.ts
+++ b/src/app/api/periods/[periodId]/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { hasRole } from '@/lib/permissions';
+import { getNextPhase, phaseOrder } from '@/lib/workflow';
+import type { Role, Phase } from '@prisma/client';
+
+interface RouteParams {
+  params: Promise<{ periodId: string }>;
+}
+
+// GET /api/periods/[periodId] - 評価期間詳細取得
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth();
+    const { periodId } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const period = await prisma.evaluationPeriod.findUnique({
+      where: { id: periodId },
+      include: {
+        _count: {
+          select: {
+            sheets: true,
+          },
+        },
+      },
+    });
+
+    if (!period) {
+      return NextResponse.json({ error: '評価期間が見つかりません' }, { status: 404 });
+    }
+
+    // 各フェーズのシート数を集計
+    const phaseStats = await prisma.evaluationSheet.groupBy({
+      by: ['status'],
+      where: { periodId },
+      _count: true,
+    });
+
+    const phaseStatsMap = Object.fromEntries(
+      phaseStats.map((stat) => [stat.status, stat._count])
+    );
+
+    return NextResponse.json({
+      ...period,
+      sheetsCount: period._count.sheets,
+      phaseStats: phaseStatsMap,
+      _count: undefined,
+    });
+  } catch (error) {
+    console.error('Error fetching period:', error);
+    return NextResponse.json({ error: '評価期間の取得に失敗しました' }, { status: 500 });
+  }
+}
+
+// PATCH /api/periods/[periodId] - 評価期間更新（フェーズ切替等）
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth();
+    const { periodId } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const { currentPhase, isActive } = body as {
+      currentPhase?: Phase;
+      isActive?: boolean;
+    };
+
+    const period = await prisma.evaluationPeriod.findUnique({
+      where: { id: periodId },
+    });
+
+    if (!period) {
+      return NextResponse.json({ error: '評価期間が見つかりません' }, { status: 404 });
+    }
+
+    const updateData: { currentPhase?: Phase; isActive?: boolean } = {};
+
+    // フェーズ切替
+    if (currentPhase !== undefined) {
+      // フェーズの順序チェック（逆方向への切替は警告のみ）
+      const currentIndex = phaseOrder.indexOf(period.currentPhase);
+      const newIndex = phaseOrder.indexOf(currentPhase);
+
+      if (newIndex < currentIndex) {
+        // 逆方向への切替は許可するが、警告をログに出力
+        console.warn(
+          `Phase reversal: ${period.currentPhase} -> ${currentPhase} for period ${periodId}`
+        );
+      }
+
+      updateData.currentPhase = currentPhase;
+    }
+
+    // アクティブ状態の切替
+    if (isActive !== undefined) {
+      // 他のアクティブな期間を非アクティブにする
+      if (isActive) {
+        await prisma.evaluationPeriod.updateMany({
+          where: { isActive: true, id: { not: periodId } },
+          data: { isActive: false },
+        });
+      }
+      updateData.isActive = isActive;
+    }
+
+    const updatedPeriod = await prisma.evaluationPeriod.update({
+      where: { id: periodId },
+      data: updateData,
+    });
+
+    return NextResponse.json(updatedPeriod);
+  } catch (error) {
+    console.error('Error updating period:', error);
+    return NextResponse.json({ error: '評価期間の更新に失敗しました' }, { status: 500 });
+  }
+}
+
+// DELETE /api/periods/[periodId] - 評価期間削除
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth();
+    const { periodId } = await params;
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const period = await prisma.evaluationPeriod.findUnique({
+      where: { id: periodId },
+      include: {
+        _count: {
+          select: { sheets: true },
+        },
+      },
+    });
+
+    if (!period) {
+      return NextResponse.json({ error: '評価期間が見つかりません' }, { status: 404 });
+    }
+
+    // シートが存在する場合は削除不可
+    if (period._count.sheets > 0) {
+      return NextResponse.json(
+        { error: 'シートが存在する評価期間は削除できません' },
+        { status: 400 }
+      );
+    }
+
+    await prisma.evaluationPeriod.delete({
+      where: { id: periodId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting period:', error);
+    return NextResponse.json({ error: '評価期間の削除に失敗しました' }, { status: 500 });
+  }
+}

--- a/src/app/api/periods/route.ts
+++ b/src/app/api/periods/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { hasRole } from '@/lib/permissions';
+import type { Role, Half, Phase } from '@prisma/client';
+
+// GET /api/periods - 評価期間一覧取得
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const periods = await prisma.evaluationPeriod.findMany({
+      orderBy: [{ year: 'desc' }, { half: 'desc' }],
+      include: {
+        _count: {
+          select: {
+            sheets: true,
+          },
+        },
+      },
+    });
+
+    const periodsWithStats = periods.map((period) => ({
+      ...period,
+      sheetsCount: period._count.sheets,
+      _count: undefined,
+    }));
+
+    return NextResponse.json(periodsWithStats);
+  } catch (error) {
+    console.error('Error fetching periods:', error);
+    return NextResponse.json({ error: '評価期間の取得に失敗しました' }, { status: 500 });
+  }
+}
+
+// POST /api/periods - 評価期間作成
+export async function POST(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasRole(userRoles, 'hr')) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const { name, year, half, startDate, endDate } = body as {
+      name: string;
+      year: number;
+      half: Half;
+      startDate: string;
+      endDate: string;
+    };
+
+    if (!name || !year || !half || !startDate || !endDate) {
+      return NextResponse.json({ error: '必須項目が不足しています' }, { status: 400 });
+    }
+
+    // 同じ年度・半期の期間が既に存在するかチェック
+    const existing = await prisma.evaluationPeriod.findFirst({
+      where: { year, half },
+    });
+
+    if (existing) {
+      return NextResponse.json(
+        { error: 'この年度・半期の評価期間は既に存在します' },
+        { status: 400 }
+      );
+    }
+
+    const period = await prisma.evaluationPeriod.create({
+      data: {
+        name,
+        year,
+        half,
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+        currentPhase: 'goal_setting',
+        isActive: false,
+      },
+    });
+
+    return NextResponse.json(period, { status: 201 });
+  } catch (error) {
+    console.error('Error creating period:', error);
+    return NextResponse.json({ error: '評価期間の作成に失敗しました' }, { status: 500 });
+  }
+}

--- a/src/app/api/team/route.ts
+++ b/src/app/api/team/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { hasAnyRole } from '@/lib/permissions';
+import type { Role } from '@prisma/client';
+
+// GET /api/team - 部下一覧取得
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+    }
+
+    const userRoles = (session.user.roles || ['employee']) as Role[];
+
+    if (!hasAnyRole(userRoles, ['manager', 'hr'])) {
+      return NextResponse.json({ error: '権限がありません' }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const periodId = searchParams.get('periodId');
+
+    // 管理対象の従業員IDを取得
+    const managedAssignments = await prisma.periodAssignment.findMany({
+      where: {
+        managerId: session.user.id,
+        ...(periodId ? { periodId } : {}),
+      },
+      select: {
+        userId: true,
+        periodId: true,
+        department: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        currentGrade: true,
+      },
+    });
+
+    if (managedAssignments.length === 0) {
+      return NextResponse.json([]);
+    }
+
+    // ユニークなperiodIdを取得
+    const periodIds = [...new Set(managedAssignments.map((a) => a.periodId))];
+    const userIds = [...new Set(managedAssignments.map((a) => a.userId))];
+
+    // 部下のシートを取得
+    const sheets = await prisma.evaluationSheet.findMany({
+      where: {
+        userId: { in: userIds },
+        periodId: { in: periodIds },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            employeeNumber: true,
+          },
+        },
+        period: {
+          select: {
+            id: true,
+            name: true,
+            year: true,
+            half: true,
+            currentPhase: true,
+          },
+        },
+        goals: {
+          select: {
+            id: true,
+            weight: true,
+          },
+        },
+      },
+      orderBy: [{ period: { year: 'desc' } }, { user: { name: 'asc' } }],
+    });
+
+    // アサインメント情報をマップ
+    const assignmentMap = new Map(
+      managedAssignments.map((a) => [`${a.userId}-${a.periodId}`, a])
+    );
+
+    // シートに部署・等級情報を追加
+    const sheetsWithDetails = sheets.map((sheet) => {
+      const assignment = assignmentMap.get(`${sheet.userId}-${sheet.periodId}`);
+      return {
+        ...sheet,
+        goalsCount: sheet.goals.length,
+        totalWeight: sheet.goals.reduce((sum, g) => sum + g.weight, 0),
+        goals: undefined,
+        department: assignment?.department || null,
+        currentGrade: assignment?.currentGrade || null,
+      };
+    });
+
+    return NextResponse.json(sheetsWithDetails);
+  } catch (error) {
+    console.error('Error fetching team:', error);
+    return NextResponse.json({ error: '部下一覧の取得に失敗しました' }, { status: 500 });
+  }
+}

--- a/src/components/hr/employees-list.tsx
+++ b/src/components/hr/employees-list.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Button, Textfield } from '@giftee/abukuma-react';
+import { employeesApi, type EmployeeSheet, ApiError } from '@/lib/api-client';
+import { phaseLabels } from '@/lib/workflow';
+import { gradeLabels } from '@/types/evaluation';
+import type { Phase, Grade } from '@prisma/client';
+
+export function EmployeesList() {
+  const [employees, setEmployees] = useState<EmployeeSheet[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+
+  const fetchEmployees = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const data = await employeesApi.list({
+        search: search || undefined,
+      });
+      setEmployees(data);
+      setError(null);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('従業員一覧の取得に失敗しました');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [search]);
+
+  useEffect(() => {
+    fetchEmployees();
+  }, [fetchEmployees]);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSearch(searchInput);
+  };
+
+  // フェーズごとにグループ化
+  const groupedByPhase = employees.reduce(
+    (acc, emp) => {
+      const phase = emp.status as Phase;
+      if (!acc[phase]) {
+        acc[phase] = [];
+      }
+      acc[phase].push(emp);
+      return acc;
+    },
+    {} as Record<Phase, EmployeeSheet[]>
+  );
+
+  if (error) {
+    return (
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)', borderLeft: '4px solid #f44336' }}
+      >
+        <p className="ab-text-body-m" style={{ color: '#f44336' }}>
+          {error}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ab-flex ab-flex-column ab-gap-6">
+      {/* 検索 */}
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <h2 className="ab-text-heading-m ab-text-default ab-mb-1">従業員検索</h2>
+        <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+          名前、メールアドレス、社員番号で検索
+        </p>
+        <form onSubmit={handleSearch} className="ab-flex ab-gap-2">
+          <div style={{ flex: 1 }}>
+            <Textfield
+              placeholder="検索キーワード"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+            />
+          </div>
+          <Button type="submit" variant="default">
+            検索
+          </Button>
+          {search && (
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={() => {
+                setSearch('');
+                setSearchInput('');
+              }}
+            >
+              クリア
+            </Button>
+          )}
+        </form>
+      </div>
+
+      {/* 結果 */}
+      {isLoading ? (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <p className="ab-text-body-m ab-text-secondary">読み込み中...</p>
+        </div>
+      ) : employees.length === 0 ? (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <p className="ab-text-body-m ab-text-secondary">
+            {search ? '検索結果がありません' : '従業員データがまだ登録されていません'}
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* サマリー */}
+          <div
+            className="ab-bg-base ab-rounded-md ab-p-4"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+          >
+            <h2 className="ab-text-heading-m ab-text-default ab-mb-4">
+              フェーズ別サマリー
+            </h2>
+            <div
+              className="ab-grid ab-gap-2"
+              style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}
+            >
+              {Object.entries(phaseLabels).map(([phase, label]) => (
+                <div
+                  key={phase}
+                  className="ab-flex ab-items-center ab-justify-between ab-p-2 ab-rounded-md"
+                  style={{ backgroundColor: '#f5f5f5' }}
+                >
+                  <span className="ab-text-body-s ab-text-secondary">{label}</span>
+                  <span className="ab-text-body-m ab-text-default">
+                    {groupedByPhase[phase as Phase]?.length || 0}名
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 従業員一覧 */}
+          <div
+            className="ab-bg-base ab-rounded-md ab-p-4"
+            style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+          >
+            <h2 className="ab-text-heading-m ab-text-default ab-mb-1">
+              従業員一覧
+            </h2>
+            <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+              {employees.length}名
+            </p>
+
+            <div className="ab-flex ab-flex-column ab-gap-2">
+              {employees.map((emp) => (
+                <Link
+                  key={emp.id}
+                  href={`/sheet/${emp.id}`}
+                  className="ab-flex ab-items-center ab-justify-between ab-p-3 ab-rounded-md"
+                  style={{
+                    textDecoration: 'none',
+                    backgroundColor: '#f5f5f5',
+                  }}
+                >
+                  <div className="ab-flex ab-flex-column ab-gap-1">
+                    <div className="ab-flex ab-items-center ab-gap-2">
+                      <span className="ab-text-body-m ab-text-default">
+                        {emp.user.name}
+                      </span>
+                      <span className="ab-text-body-s ab-text-secondary">
+                        ({emp.user.employeeNumber})
+                      </span>
+                    </div>
+                    <span className="ab-text-body-s ab-text-secondary">
+                      {emp.department?.name || '-'} /{' '}
+                      {gradeLabels[emp.currentGrade as Grade] || '-'} / 上長:{' '}
+                      {emp.manager?.name || '-'}
+                    </span>
+                  </div>
+                  <div className="ab-flex ab-items-center ab-gap-3">
+                    <div className="ab-flex ab-flex-column ab-items-end ab-gap-1">
+                      <span
+                        className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+                        style={{
+                          backgroundColor:
+                            emp.status === 'finalized' ? '#4caf50' : '#1976d2',
+                          padding: '2px 8px',
+                        }}
+                      >
+                        {phaseLabels[emp.status as Phase]}
+                      </span>
+                      <span className="ab-text-body-s ab-text-secondary">
+                        目標: {emp.goalsCount}/6 | ウェイト: {emp.totalWeight}%
+                      </span>
+                    </div>
+                    <span className="ab-text-body-m" style={{ color: '#1976d2' }}>
+                      →
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/hr/index.ts
+++ b/src/components/hr/index.ts
@@ -1,0 +1,2 @@
+export { EmployeesList } from './employees-list';
+export { PeriodsList } from './periods-list';

--- a/src/components/hr/periods-list.tsx
+++ b/src/components/hr/periods-list.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Button, Textfield, Select } from '@giftee/abukuma-react';
+import { periodsApi, type Period, ApiError } from '@/lib/api-client';
+import { phaseLabels, phaseOrder } from '@/lib/workflow';
+import { halfLabels } from '@/types/evaluation';
+import type { Phase, Half } from '@prisma/client';
+
+export function PeriodsList() {
+  const [periods, setPeriods] = useState<Period[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  // 新規作成フォーム
+  const [newPeriod, setNewPeriod] = useState({
+    name: '',
+    year: new Date().getFullYear(),
+    half: 'first' as 'first' | 'second',
+    startDate: '',
+    endDate: '',
+  });
+
+  const fetchPeriods = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const data = await periodsApi.list();
+      setPeriods(data);
+      setError(null);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('評価期間の取得に失敗しました');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPeriods();
+  }, [fetchPeriods]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newPeriod.name || !newPeriod.startDate || !newPeriod.endDate) {
+      setError('すべての項目を入力してください');
+      return;
+    }
+
+    try {
+      setCreating(true);
+      await periodsApi.create(newPeriod);
+      setShowCreateForm(false);
+      setNewPeriod({
+        name: '',
+        year: new Date().getFullYear(),
+        half: 'first',
+        startDate: '',
+        endDate: '',
+      });
+      await fetchPeriods();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('評価期間の作成に失敗しました');
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handlePhaseChange = async (periodId: string, newPhase: Phase) => {
+    try {
+      setUpdating(periodId);
+      await periodsApi.update(periodId, { currentPhase: newPhase });
+      await fetchPeriods();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('フェーズの更新に失敗しました');
+      }
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  const handleToggleActive = async (periodId: string, isActive: boolean) => {
+    try {
+      setUpdating(periodId);
+      await periodsApi.update(periodId, { isActive });
+      await fetchPeriods();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('アクティブ状態の更新に失敗しました');
+      }
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <p className="ab-text-body-m ab-text-secondary">読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ab-flex ab-flex-column ab-gap-6">
+      {/* エラー表示 */}
+      {error && (
+        <div
+          className="ab-rounded-md ab-p-4"
+          style={{ backgroundColor: '#ffebee', border: '1px solid #f44336' }}
+        >
+          <p className="ab-text-body-m" style={{ color: '#f44336' }}>
+            {error}
+          </p>
+          <Button
+            variant="outlined"
+            onClick={() => setError(null)}
+            style={{ marginTop: '8px' }}
+          >
+            閉じる
+          </Button>
+        </div>
+      )}
+
+      {/* 新規作成ボタン */}
+      {!showCreateForm && (
+        <div>
+          <Button variant="default" onClick={() => setShowCreateForm(true)}>
+            新規評価期間を作成
+          </Button>
+        </div>
+      )}
+
+      {/* 新規作成フォーム */}
+      {showCreateForm && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-4">
+            新規評価期間の作成
+          </h2>
+          <form onSubmit={handleCreate} className="ab-flex ab-flex-column ab-gap-4">
+            <Textfield
+              label="期間名"
+              placeholder="例: 2026年度上期"
+              value={newPeriod.name}
+              onChange={(e) => setNewPeriod({ ...newPeriod, name: e.target.value })}
+              required
+            />
+            <div className="ab-flex ab-gap-4">
+              <div style={{ flex: 1 }}>
+                <Textfield
+                  label="年度"
+                  type="number"
+                  value={newPeriod.year.toString()}
+                  onChange={(e) =>
+                    setNewPeriod({ ...newPeriod, year: parseInt(e.target.value) || 0 })
+                  }
+                  required
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <Select
+                  label="半期"
+                  value={newPeriod.half}
+                  options={[
+                    { value: 'first', label: '上期' },
+                    { value: 'second', label: '下期' },
+                  ]}
+                  onChange={(e) =>
+                    setNewPeriod({
+                      ...newPeriod,
+                      half: e.target.value as 'first' | 'second',
+                    })
+                  }
+                />
+              </div>
+            </div>
+            <div className="ab-flex ab-gap-4">
+              <div style={{ flex: 1 }}>
+                <Textfield
+                  label="開始日"
+                  type="date"
+                  value={newPeriod.startDate}
+                  onChange={(e) =>
+                    setNewPeriod({ ...newPeriod, startDate: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <Textfield
+                  label="終了日"
+                  type="date"
+                  value={newPeriod.endDate}
+                  onChange={(e) =>
+                    setNewPeriod({ ...newPeriod, endDate: e.target.value })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="ab-flex ab-gap-2">
+              <Button type="submit" variant="default" disabled={creating}>
+                {creating ? '作成中...' : '作成'}
+              </Button>
+              <Button
+                type="button"
+                variant="outlined"
+                onClick={() => setShowCreateForm(false)}
+                disabled={creating}
+              >
+                キャンセル
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* 評価期間一覧 */}
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <h2 className="ab-text-heading-m ab-text-default ab-mb-1">評価期間一覧</h2>
+        <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+          {periods.length}件の評価期間
+        </p>
+
+        {periods.length === 0 ? (
+          <p className="ab-text-body-m ab-text-secondary">
+            評価期間がまだ作成されていません
+          </p>
+        ) : (
+          <div className="ab-flex ab-flex-column ab-gap-4">
+            {periods.map((period) => (
+              <div
+                key={period.id}
+                className="ab-p-4 ab-rounded-md"
+                style={{
+                  backgroundColor: period.isActive ? '#e3f2fd' : '#f5f5f5',
+                  border: period.isActive ? '2px solid #1976d2' : '1px solid #e0e0e0',
+                }}
+              >
+                <div className="ab-flex ab-items-start ab-justify-between ab-mb-3">
+                  <div>
+                    <div className="ab-flex ab-items-center ab-gap-2 ab-mb-1">
+                      <span className="ab-text-heading-s ab-text-default">
+                        {period.name}
+                      </span>
+                      {period.isActive && (
+                        <span
+                          className="ab-text-body-s ab-rounded-md"
+                          style={{
+                            backgroundColor: '#1976d2',
+                            color: 'white',
+                            padding: '2px 8px',
+                          }}
+                        >
+                          アクティブ
+                        </span>
+                      )}
+                    </div>
+                    <p className="ab-text-body-s ab-text-secondary">
+                      {period.year}年 {halfLabels[period.half as Half]} |{' '}
+                      {new Date(period.startDate).toLocaleDateString()} 〜{' '}
+                      {new Date(period.endDate).toLocaleDateString()} | シート数:{' '}
+                      {period.sheetsCount}
+                    </p>
+                  </div>
+                  <Button
+                    variant={period.isActive ? 'outlined' : 'default'}
+                    onClick={() => handleToggleActive(period.id, !period.isActive)}
+                    disabled={updating === period.id}
+                  >
+                    {period.isActive ? '非アクティブ化' : 'アクティブ化'}
+                  </Button>
+                </div>
+
+                <div className="ab-flex ab-items-center ab-gap-4">
+                  <span className="ab-text-body-s ab-text-secondary">
+                    現在のフェーズ:
+                  </span>
+                  <Select
+                    value={period.currentPhase}
+                    options={phaseOrder.map((phase) => ({
+                      value: phase,
+                      label: phaseLabels[phase],
+                    }))}
+                    onChange={(e) =>
+                      handlePhaseChange(period.id, e.target.value as Phase)
+                    }
+                    disabled={updating === period.id}
+                    style={{ minWidth: '200px' }}
+                  />
+                  {updating === period.id && (
+                    <span className="ab-text-body-s ab-text-secondary">
+                      更新中...
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/team/index.ts
+++ b/src/components/team/index.ts
@@ -1,0 +1,1 @@
+export { TeamList } from './team-list';

--- a/src/components/team/team-list.tsx
+++ b/src/components/team/team-list.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { teamApi, type TeamMember, ApiError } from '@/lib/api-client';
+import { phaseLabels } from '@/lib/workflow';
+import { halfLabels, gradeLabels } from '@/types/evaluation';
+import type { Phase, Half, Grade } from '@prisma/client';
+
+export function TeamList() {
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchTeam() {
+      try {
+        const data = await teamApi.list();
+        setMembers(data);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('部下一覧の取得に失敗しました');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchTeam();
+  }, []);
+
+  // 現在の期間でグループ化
+  const currentPeriodMembers = members.filter(
+    (m) => m.period.currentPhase !== 'finalized'
+  );
+  const pastPeriodMembers = members.filter(
+    (m) => m.period.currentPhase === 'finalized'
+  );
+
+  if (isLoading) {
+    return (
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <p className="ab-text-body-m ab-text-secondary">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)', borderLeft: '4px solid #f44336' }}
+      >
+        <p className="ab-text-body-m" style={{ color: '#f44336' }}>
+          {error}
+        </p>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div
+        className="ab-bg-base ab-rounded-md ab-p-4"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+      >
+        <p className="ab-text-body-m ab-text-secondary">
+          管理対象の従業員はまだ登録されていません
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ab-flex ab-flex-column ab-gap-6">
+      {/* 現在の評価期間 */}
+      {currentPeriodMembers.length > 0 && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">
+            現在の評価期間
+          </h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+            {currentPeriodMembers[0]?.period.year}年{' '}
+            {halfLabels[currentPeriodMembers[0]?.period.half as Half]}（
+            {currentPeriodMembers[0]?.period.name}）
+          </p>
+
+          <div className="ab-flex ab-flex-column ab-gap-2">
+            {currentPeriodMembers.map((member) => (
+              <Link
+                key={member.id}
+                href={`/sheet/${member.id}`}
+                className="ab-flex ab-items-center ab-justify-between ab-p-3 ab-rounded-md"
+                style={{
+                  textDecoration: 'none',
+                  backgroundColor: '#f5f5f5',
+                  transition: 'background-color 0.2s',
+                }}
+              >
+                <div className="ab-flex ab-flex-column ab-gap-1">
+                  <span className="ab-text-body-m ab-text-default">
+                    {member.user.name}
+                  </span>
+                  <span className="ab-text-body-s ab-text-secondary">
+                    {member.department?.name || '-'} /{' '}
+                    {gradeLabels[member.currentGrade as Grade] || '-'}
+                  </span>
+                </div>
+                <div className="ab-flex ab-items-center ab-gap-3">
+                  <div className="ab-flex ab-flex-column ab-items-end ab-gap-1">
+                    <span
+                      className="ab-text-body-s ab-text-on-primary ab-rounded-md"
+                      style={{ backgroundColor: '#1976d2', padding: '2px 8px' }}
+                    >
+                      {phaseLabels[member.status as Phase]}
+                    </span>
+                    <span className="ab-text-body-s ab-text-secondary">
+                      目標: {member.goalsCount}/6 | ウェイト: {member.totalWeight}%
+                    </span>
+                  </div>
+                  <span className="ab-text-body-m" style={{ color: '#1976d2' }}>
+                    →
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 過去の評価期間 */}
+      {pastPeriodMembers.length > 0 && (
+        <div
+          className="ab-bg-base ab-rounded-md ab-p-4"
+          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.1)' }}
+        >
+          <h2 className="ab-text-heading-m ab-text-default ab-mb-1">
+            過去の評価期間
+          </h2>
+          <p className="ab-text-body-s ab-text-secondary ab-mb-4">
+            確定済みの評価シート
+          </p>
+
+          <div className="ab-flex ab-flex-column ab-gap-2">
+            {pastPeriodMembers.map((member) => (
+              <Link
+                key={member.id}
+                href={`/sheet/${member.id}`}
+                className="ab-flex ab-items-center ab-justify-between ab-p-3 ab-rounded-md"
+                style={{
+                  textDecoration: 'none',
+                  backgroundColor: '#f5f5f5',
+                }}
+              >
+                <div className="ab-flex ab-flex-column ab-gap-1">
+                  <span className="ab-text-body-m ab-text-default">
+                    {member.user.name}
+                  </span>
+                  <span className="ab-text-body-s ab-text-secondary">
+                    {member.period.year}年 {halfLabels[member.period.half as Half]}
+                  </span>
+                </div>
+                <span
+                  className="ab-text-body-s ab-rounded-md"
+                  style={{
+                    backgroundColor: '#4caf50',
+                    color: 'white',
+                    padding: '2px 8px',
+                  }}
+                >
+                  確定済
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -97,6 +97,48 @@ export const totalEvaluationApi = {
     }),
 };
 
+// Team API (Manager)
+export const teamApi = {
+  list: (periodId?: string) =>
+    fetchApi<TeamMember[]>('/api/team', {
+      params: periodId ? { periodId } : undefined,
+    }),
+};
+
+// Employees API (HR)
+export const employeesApi = {
+  list: (params?: { periodId?: string; search?: string; departmentId?: string; status?: string }) =>
+    fetchApi<EmployeeSheet[]>('/api/employees', {
+      params: params
+        ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined)) as Record<string, string>
+        : undefined,
+    }),
+};
+
+// Periods API (HR)
+export const periodsApi = {
+  list: () => fetchApi<Period[]>('/api/periods'),
+
+  get: (periodId: string) => fetchApi<PeriodDetail>(`/api/periods/${periodId}`),
+
+  create: (data: PeriodCreateData) =>
+    fetchApi<Period>('/api/periods', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  update: (periodId: string, data: PeriodUpdateData) =>
+    fetchApi<Period>(`/api/periods/${periodId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (periodId: string) =>
+    fetchApi<{ success: boolean }>(`/api/periods/${periodId}`, {
+      method: 'DELETE',
+    }),
+};
+
 // Types for API responses and requests
 export interface SheetSummary {
   id: string;
@@ -245,4 +287,94 @@ export interface TotalEvaluationData {
   hrTreatment?: string | null;
   hrSalaryChange?: number | null;
   hrGrade?: string | null;
+}
+
+// Team API Types
+export interface TeamMember {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    employeeNumber: string;
+  };
+  period: {
+    id: string;
+    name: string;
+    year: number;
+    half: string;
+    currentPhase: string;
+  };
+  department: {
+    id: string;
+    name: string;
+  } | null;
+  currentGrade: string | null;
+  goalsCount: number;
+  totalWeight: number;
+}
+
+// Employees API Types
+export interface EmployeeSheet {
+  id: string;
+  userId: string;
+  periodId: string;
+  status: string;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    employeeNumber: string;
+  };
+  period: {
+    id: string;
+    name: string;
+    year: number;
+    half: string;
+    currentPhase: string;
+  };
+  department: {
+    id: string;
+    name: string;
+  } | null;
+  manager: {
+    id: string;
+    name: string;
+  } | null;
+  currentGrade: string | null;
+  goalsCount: number;
+  totalWeight: number;
+}
+
+// Periods API Types
+export interface Period {
+  id: string;
+  name: string;
+  year: number;
+  half: string;
+  startDate: string;
+  endDate: string;
+  currentPhase: string;
+  isActive: boolean;
+  sheetsCount: number;
+}
+
+export interface PeriodDetail extends Period {
+  phaseStats: Record<string, number>;
+}
+
+export interface PeriodCreateData {
+  name: string;
+  year: number;
+  half: 'first' | 'second';
+  startDate: string;
+  endDate: string;
+}
+
+export interface PeriodUpdateData {
+  currentPhase?: string;
+  isActive?: boolean;
 }


### PR DESCRIPTION
## Summary
- 管理職向け部下一覧画面（/team）を実装
- HR向け全従業員一覧画面（/employees）を実装
- HR向け評価期間管理画面（/periods）を実装

## 追加されたAPI
- `GET /api/team` - 部下一覧取得
- `GET /api/employees` - 全従業員一覧（検索対応）
- `GET/POST /api/periods` - 評価期間一覧・作成
- `GET/PATCH/DELETE /api/periods/[periodId]` - 評価期間管理・フェーズ切替

## 追加されたコンポーネント
- `TeamList` - 部下のシート一覧表示
- `EmployeesList` - 全従業員検索・一覧
- `PeriodsList` - 評価期間作成・フェーズ切替

## Test plan
- [ ] 管理職でログインして /team で部下一覧が表示される
- [ ] HRでログインして /employees で全従業員が表示・検索できる
- [ ] HRでログインして /periods で評価期間の一覧・作成・フェーズ切替ができる

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)